### PR TITLE
69 bug with lead time and time generated calculation

### DIFF
--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -117,7 +117,7 @@ class SeriesProvider():
         :return series
         '''
         ###See if we can get the outputs from the database
-        dbi = map_to_SS_Instance() 
+        dbi = series_storage_factory() 
         requestedSeries = dbi.select_output(requestDesc)
 
         ###Do we have enough outputs? 


### PR DESCRIPTION
So the issue was two things. First the test case had issues. An attribute was wrong and the date time was quering for the generated time not varification time. Secondly the way I was trying to calculate those in the query, did not work. So I fixed that for both quering outputs and predictions.