### PR TITLE
Added extra_hosts to docker-compose file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,7 +1,7 @@
 POSTGRES_USER=user
 POSTGRES_PASSWORD=password
 POSTGRES_DB=semaphoredb
-DB_LOCATION_STRING=postgresql+psycopg2://root:root@host.docker.internal:5435/semaphoredb
+DB_LOCATION_STRING=postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@host.docker.internal:5435/${POSTGRES_DB}
 ISERIESSTORAGE_INSTANCE= SQLAlchemyORM_Postgres
 DSPEC_FOLDER_PATH= /app/data/dspec/
 MODEL_FOLDER_PATH= /app/data/models/

--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,6 @@
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password
+POSTGRES_DB=semaphoredb
 DB_LOCATION_STRING=postgresql+psycopg2://root:root@host.docker.internal:5435/semaphoredb
 ISERIESSTORAGE_INSTANCE= SQLAlchemyORM_Postgres
 DSPEC_FOLDER_PATH= /app/data/dspec/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     #   - semaphore-net
     volumes:
       - ./data:/app/data
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   api:
     container_name: semaphore-api
     platform: linux/amd64


### PR DESCRIPTION
Now, you must define your `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` as actual .env variables. See `.env.dist`. This means that you must also change your `DB_LOCATION_STRING` to match your credentials. You may also want to change your `DB_HOST_PORT` to avoid any port conflicts (in case two users run the containers at the same time.)
 
You can connect to the DB from your local pgAdmin app like so:
<img width="526" alt="register1" src="https://github.com/conrad-blucher-institute/semaphore/assets/74482285/068422e4-98d8-4115-b6a7-43d08360d3e2">
<img width="523" alt="register2" src="https://github.com/conrad-blucher-institute/semaphore/assets/74482285/9e2fc467-1fc4-4c6b-b062-b6ca997cd814">
You must be connected to the TAMUCC VPN. The port, username, and password must all match what you put in your .env.

(*NOTE:: If you ran the containers on sherlock before you will need to remove the `psql-data` volume by using `docker volume rm psql-data` such that you can initialize your new username and password.)