### PR TITLE
added timing info where needed and removed dataClasification

### DIFF
--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -23,7 +23,6 @@
             "series": "dWaterTmp",
             "unit": "celsius",
             "type": "float",
-            "dataClassification": "actual",
             "interval": 3600,
             "range": [0, -23]
         },
@@ -34,7 +33,6 @@
             "series": "dAirTmp",
             "unit": "celsius",
             "type": "float",
-            "dataClassification": "actual",
             "interval": 3600,
             "range": [0, -23]
         },
@@ -45,7 +43,6 @@
             "series": "pAirTemp",
             "unit": "celsius",
             "type": "float",
-            "dataClassification": "prediction",
             "interval": 10800,
             "range": [16, 1]
         }

--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -1,6 +1,6 @@
 {
     "modelName": "MLP-OP",
-    "modelVersion": "1.0.0",
+    "modelVersion": "2.0.0",
     "author": "Christian Duff",
     "modelFileName": "MLP-OP",
     "timingInfo":{

--- a/data/dspec/ThermalRefuge.json
+++ b/data/dspec/ThermalRefuge.json
@@ -3,6 +3,11 @@
     "modelVersion": "1.0.0",
     "author": "Andrew DeSimone",
     "modelFileName": "thermalrefugemodel",
+    "timingInfo":{
+        "offset": 0,
+        "interval": 3600
+
+    },
     "outputInfo": {
         "outputMethod": "OnePackedFloat",
         "leadTime": 0,


### PR DESCRIPTION
I think that really there was only the one remnant of the old dspec in MLP with the dataClassification, everything else was included in the despc.py file. I wasn't completely sure what timing info to put for the thermal refuge so I just put hourly. 