### PR TITLE
Fixing crash on LIGHTHOUSE returning all null values

### DIFF
--- a/src/DataIngestion/DataIngestion/LIGHTHOUSE.py
+++ b/src/DataIngestion/DataIngestion/LIGHTHOUSE.py
@@ -86,7 +86,6 @@ class LIGHTHOUSE(IDataIngestion):
         ### Get LIGHTHOUSE data
         # Build the URL to hit
         url = f'http://lighthouse.tamucc.edu/pd?stnlist={lighthouseLocationCode}&serlist={sim[SIMSeriesCodeIndex]}&when={fromString}%2C{toString}&whentz=UTC0&-action=app_json&unit=metric&elev=stnd'
-        print(url)
         apiReturn = self.__api_request(url)
         if apiReturn == None:
             log(f'LIGHTHOUSE | __pull_pd_endpoint_dataPoint | For unknown reason fetch failed for {seriesDescription}{timeDescription}')

--- a/src/DataIngestion/DataIngestion/LIGHTHOUSE.py
+++ b/src/DataIngestion/DataIngestion/LIGHTHOUSE.py
@@ -86,6 +86,7 @@ class LIGHTHOUSE(IDataIngestion):
         ### Get LIGHTHOUSE data
         # Build the URL to hit
         url = f'http://lighthouse.tamucc.edu/pd?stnlist={lighthouseLocationCode}&serlist={sim[SIMSeriesCodeIndex]}&when={fromString}%2C{toString}&whentz=UTC0&-action=app_json&unit=metric&elev=stnd'
+        print(url)
         apiReturn = self.__api_request(url)
         if apiReturn == None:
             log(f'LIGHTHOUSE | __pull_pd_endpoint_dataPoint | For unknown reason fetch failed for {seriesDescription}{timeDescription}')
@@ -124,9 +125,13 @@ class LIGHTHOUSE(IDataIngestion):
                     lat
                 ))
 
-        ### Build Series, send data to DB, return data
-        resultSeries = Series(seriesDescription, timeDescription)
-        resultSeries.data = inputs
-        #Insert series into DB
-        self.seriesStorage.insert_input(resultSeries)
-        return resultSeries
+        if(len(inputs) > 0):
+            ### Build Series, send data to DB, return data
+            resultSeries = Series(seriesDescription, timeDescription)
+            resultSeries.data = inputs
+            #Insert series into DB
+            self.seriesStorage.insert_input(resultSeries)
+            return resultSeries
+        else:
+            log("Lighthouse returned no non null inputs")
+            return None


### PR DESCRIPTION
LIGHTHOUSE was crashing when the PD returned only nulls. When we tried to insert the empty list into the DB the crash happens. I fixed this by having the LIGHTHOUSE class check and see if no good inputs were found, and if so, it does not insert into the DB and logs what happened.