### PR TITLE
Fixing NAN 4mm bug

### DIFF
--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -163,6 +163,7 @@ class NDBC(IDataIngestion):
 
         # We convert the data from strings to float, sort it, take the four highest, and take their mean
         input_data = [float(input.dataValue) for input in full_series_inputs]
+        input_data = list(filter(lambda item: item is not None, input_data)) # Removing any Nones from the list
         four_highest = sorted(input_data)[-4:] # Get the four highest values
         mean_four_max = sum(four_highest) / 4.0
 

--- a/src/DataIngestion/DI_Classes/NOAATANDC.py
+++ b/src/DataIngestion/DI_Classes/NOAATANDC.py
@@ -248,7 +248,8 @@ class NOAATANDC(IDataIngestion):
         if data is None: return None
 
         data = data['v'].values
-        four_highest = sorted(data)[-4:]
+        input_data = list(filter(lambda item: item is not None, data)) # Removing any Nones from the list
+        four_highest = sorted(input_data)[-4:]
         mean_four_max = sum(four_highest) / 4.0
 
         input = Input(


### PR DESCRIPTION
Fixed by filtering any nones from lists before preforming the sum operation.
The sum operation returns Nan if non numeric data is within the list.
We clear Nones before selecting the four max to make sure we select the 4 highest values that we actually have.