### PR TITLE
Deactivated magnolia transform 48h

### DIFF
--- a/data/dspec/Magnolia/48/magnolia_transform_48.json
+++ b/data/dspec/Magnolia/48/magnolia_transform_48.json
@@ -5,7 +5,7 @@
     "author": "Jacob Alonzo",
     "modelFileName": "./Magnolia/48hr_leadtime_48HrsOfWind_2ndANN",
     "timingInfo":{
-        "active": true,
+        "active": false,
         "offset": 1200,
         "interval": 3600
     },


### PR DESCRIPTION
Currently isn't making predictions, because it thinks the dataIntegrityDescription is None. When dataIntegrityDescription is None it returns the unaltered series.