### PR TITLE
Series provider refector w/ tests

### DIFF
--- a/src/DataIngestion/DI_Classes/TEST_DI.py
+++ b/src/DataIngestion/DI_Classes/TEST_DI.py
@@ -20,7 +20,6 @@ ERROR_RAISE - Actually will raise an exception for you to catch
 # 
 #
 #Input
-from SeriesStorage.ISeriesStorage import series_storage_factory
 from DataClasses import Series, SeriesDescription, Input, TimeDescription
 from DataIngestion.IDataIngestion import IDataIngestion
 

--- a/src/DataIngestion/DI_Classes/TEST_DI.py
+++ b/src/DataIngestion/DI_Classes/TEST_DI.py
@@ -56,22 +56,17 @@ class TEST_DI(IDataIngestion):
                     raise Exception(f'In testing DI class {amount_of_missing} from a series that only has {len(series.data)} values!')
                 
                 series.data = self.__generate_data_with_missing(series.data, amount_of_missing)
-                print(series.data)
                 return series
 
 
     def __generate_data_with_missing(self, data: list[Input], amount_of_missing: int) -> list[Input]:
         missing_idx = random.sample(range(0, len(data)), amount_of_missing)
-        print(missing_idx)
         new_data = []
-        print('before', data)
         for idx, data in enumerate(data):
             if idx in missing_idx:
-                print(f'Missing idx {idx} skipped!')
                 continue
             else:
                 new_data.append(data)
-        print('after', new_data)
         return new_data
 
             

--- a/src/DataIngestion/DI_Classes/TEST_DI.py
+++ b/src/DataIngestion/DI_Classes/TEST_DI.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#TEST_DI.py
+#----------------------------------
+# Created By: Matthew Kastl
+# Created Date: 9/3/2024
+# version 1.0
+#----------------------------------
+""" This file is a mock ingestion class used to test other parts of SEMAPHORE. 
+To utilize this class for testing, simply write a series description with the data
+source set to: TEST_DI and the series set to one of the below that you want:
+
+COMPLETE - A series that is correct according to your time description
+MISS_# - A series is correct but is missing a # of values (Make sure your time description covers enough time ) These values will be randomly selected
+MISS_FIRST - A series that is correct but missing first value
+MISS_LAST - A series that is correct but missing last value
+ERROR_NO_RAISE - Basically just returns None as if the ingestion class encountered an error
+ERROR_RAISE - Actually will raise an exception for you to catch
+ """ 
+#----------------------------------
+# 
+#
+#Input
+from SeriesStorage.ISeriesStorage import series_storage_factory
+from DataClasses import Series, SeriesDescription, Input, TimeDescription
+from DataIngestion.IDataIngestion import IDataIngestion
+
+import random
+
+class TEST_DI(IDataIngestion):
+    
+    def ingest_series(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> Series | None:
+        match seriesDescription.dataSeries:
+            case 'COMPLETE': 
+                return self.__make_complete_series(seriesDescription, timeDescription)
+            case 'MISS_FIRST':
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+                series.data = series.data[1:]
+                return series
+            case 'MISS_LAST':
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+                series.data = series.data[:-1]
+                return series
+            case 'ERROR_NO_RAISE':
+                return None
+            case 'ERROR_RAISE':
+                raise Exception
+            case _:
+                isMiss = seriesDescription.dataSeries.find('MISS_') != -1
+                if not isMiss: 
+                    raise Exception(f'{seriesDescription.dataSeries} requested in DI testing class but couldn\'t be understood')
+
+                amount_of_missing = int(seriesDescription.dataSeries[5:])
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+
+                if amount_of_missing > len(series.data):
+                    raise Exception(f'In testing DI class {amount_of_missing} from a series that only has {len(series.data)} values!')
+                
+                series.data = self.__generate_data_with_missing(series.data, amount_of_missing)
+                print(series.data)
+                return series
+
+
+    def __generate_data_with_missing(self, data: list[Input], amount_of_missing: int) -> list[Input]:
+        missing_idx = random.sample(range(0, len(data)), amount_of_missing)
+        print(missing_idx)
+        new_data = []
+        print('before', data)
+        for idx, data in enumerate(data):
+            if idx in missing_idx:
+                print(f'Missing idx {idx} skipped!')
+                continue
+            else:
+                new_data.append(data)
+        print('after', new_data)
+        return new_data
+
+            
+    def __make_complete_series(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> Series:
+        
+        date_times = self.__generate_datetime_list(timeDescription)
+
+        data = []
+        for datetime in date_times:
+            data.append(Input(0, 'TEST', datetime, datetime, 'TEST', 'TEST'))
+        series = Series(seriesDescription, False, timeDescription)
+        series.data = data
+        return series
+    
+
+    def __generate_datetime_list(self, timeDescription: TimeDescription) -> list:
+        """This function creates a list of expected time stamps between a from time and a two time at some interval.
+        The keys are the time steps and the values are always set to None.
+        If to time and from time are equal, its only a single pair is returned as that describes a single input.
+        :param timeDescription: TimeDescription - The description of the temporal information of the request 
+        :return list[datetime]
+        """
+        # If to time == from time this is a request for a single point
+        if timeDescription.fromDateTime == timeDescription.toDateTime:
+            return [timeDescription.toDateTime]
+        
+        if timeDescription.interval.total_seconds() == 0:
+            return [timeDescription.toDateTime]
+        
+        # Define the initial time and how many time steps their are.
+        initial_time = timeDescription.fromDateTime
+        steps = int((timeDescription.toDateTime - timeDescription.fromDateTime) / timeDescription.interval)
+        steps = steps + 1 # We increment here as we are inclusive on both sides of the range of datetimes [from time, to time]
+        
+        # GenerateTimeStamp will calculate a timestamp an amount of steps away from the initial time
+        generateTimestamp = lambda initial_time, idx, interval : initial_time + (interval * idx)
+
+        # Perform list comprehension to generate a list of all the time steps we need plus another list of the same size this is all None
+        return [generateTimestamp(initial_time, idx, timeDescription.interval) for idx in range(steps)]
+            
+    

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta
 
 
 
+
 class SeriesProvider():
 
     def __init__(self) -> None:
@@ -42,20 +43,7 @@ class SeriesProvider():
             returningSeries = self.seriesStorage.insert_output(series)
 
         return returningSeries
-    
-    def save_input_series(self, series: Series):
-        """Passes a series to Series Storage to be stored.
-            :param series - The series to store.
-        """
-        
-        if (type(series.description) == SemaphoreSeriesDescription): #Check and make sure this is actually something with the proper description to be inserted
-            log(f'An input save request must be provided a series with a Series Description not a SemaphoreSeriesDescription. This series will not be saved.')
-        elif (series.description.dataSource == "SEMAPHORE"):
-            pass # Do nothing if the data source is "SEMAPHORE"
-        else:
-             self.seriesStorage.insert_input(series)
-
-        
+          
     
     def request_input(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> Series:
         """This method attempts to return a series matching a series description and a time description.
@@ -71,41 +59,28 @@ class SeriesProvider():
         # If an interval was not provided we have to make an assumption to be able to validate it. Here we assume the interval to be 6 minuets
         timeDescription.interval = timedelta(minutes=6) if timeDescription.interval == None else timeDescription.interval
         
-        # Pull data from series storage and validate it, if valid return it
-        log(f'Init DB Query...')
-        series_storage_results = self.seriesStorage.select_input(seriesDescription, timeDescription)
-        validated_series_storage_results = self.__generate_resulting_series(seriesDescription, timeDescription, series_storage_results.data)
-        if(validated_series_storage_results.isComplete):
-            return validated_series_storage_results
+        # First we check the database to see if it has the data we need
+        validated_DB_results, raw_DB_results = self.__data_base_query(seriesDescription, timeDescription)
+        if validated_DB_results.isComplete: 
+            return validated_DB_results
 
-        # If series storage results weren't valid
-        # Pull data ingestion, validate it with the series storage results, if valid return it
-        log(f'Init DI Query...')
-        data_ingestion_class = data_ingestion_factory(seriesDescription)
-        data_ingestion_results = data_ingestion_class.ingest_series(seriesDescription, timeDescription)
-        validated_merged_result = self.__generate_resulting_series(seriesDescription, timeDescription, series_storage_results.data, data_ingestion_results.data if data_ingestion_results != None else None)
-        if(validated_merged_result.isComplete):
-            inserted_series = self.save_input_series(validated_merged_result)
-            if(inserted_series is None or len(inserted_series.data) == 0):
-                log('WARNING:: A data insertion was triggered but no data was actually inserted!')
-            return validated_merged_result
+        # Next we start Data Ingestion, to go and get the data we need
+        validated_DI_results, raw_DI_results = self.__data_ingestion_query(seriesDescription, timeDescription)
+        if validated_DI_results is not None and validated_DI_results.isComplete: 
+            return validated_DI_results
         
-        if seriesDescription.dataIntegrityDescription is None:
-            log(f'Series is not complete and interpolation was not granted!')
-            return validated_merged_result
+        # If neither of those in isolation work we try merging them together
+        validated_merged_results = self.__generate_resulting_series(seriesDescription, timeDescription, raw_DB_results.data, None if raw_DI_results is None else raw_DI_results.data)
+        if validated_merged_results.isComplete: 
+            return validated_merged_results
+        elif seriesDescription.dataIntegrityDescription is None:
+            log(f'INFO:: Series is not complete and interpolation was not granted!')
+            return validated_merged_results
         
-        log(f'Init Interpolation...')
-        # If neither were valid then we attempt to interpolate, checking if we have permissions to do so inside the method
-        integrityClass = data_integrity_factory(seriesDescription.dataIntegrityDescription.call)
-        interpolation_results = integrityClass.exec(validated_merged_result)
-        validated_interpolation_results = self.__generate_resulting_series(seriesDescription, timeDescription, interpolation_results.data)
-        
-        if (not validated_interpolation_results.isComplete):
-            log('Series is not complete after interpolation!')
-            
-        self.save_input_series(validated_interpolation_results)    
-        return validated_interpolation_results
-      
+        # If we are allowed to interpolate, we interpolate the data and return that
+        # This does not guarantee all the data is there, but there is nothing more we can do.
+        return self.__data_interpolation(seriesDescription, timeDescription, validated_merged_results)
+   
     
     def request_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription: TimeDescription) -> Series: 
         ''' Takes a description of an output series and attempts to return it
@@ -117,73 +92,100 @@ class SeriesProvider():
         ###See if we can get the outputs from the database
         requestedSeries = self.seriesStorage.select_output(semaphoreSeriesDescription, timeDescription)
         return requestedSeries
+    
+
+    def __data_base_query(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> tuple[Series, Series]:
+        """ Handles the process of getting requested data from series storage, validating it, and returning both validated and raw results 
+        :param seriesDescription: SeriesDescription - The semantic description of request
+        :param timeDescription: TimeDescription - The temporal description of the request
+        :returns tuple[Series, Series]
+            - Validated results: Series - The results from the DB that have gone through validation.
+            - Raw results: Series - The raw results from the database.
+        """
+
+        log(f'Init DB Query...')
+        series_storage_results = self.seriesStorage.select_input(seriesDescription, timeDescription)
+        validated_series_storage_results = self.__generate_resulting_series(seriesDescription, timeDescription, series_storage_results.data)
+        return validated_series_storage_results, series_storage_results
+        
+
+    def __data_ingestion_query(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> tuple[Series | None, Series | None]:
+        """ Handles the process of getting requested data from series storage, validating it, and returning both validated and raw results 
+        :param seriesDescription: SeriesDescription - The semantic description of request
+        :param timeDescription: TimeDescription - The temporal description of the request
+        :returns tuple[Series, Series] | None
+            - Series | None - The results from the DI that have gone through validation or None if data ingestion encountered an error.
+            - Series | None - The raw results from the ingestion class or None if data ingestion encountered an error.
+        """
+        log(f'Init DI Query...')
+        data_ingestion_class = data_ingestion_factory(seriesDescription)
+        data_ingestion_results = data_ingestion_class.ingest_series(seriesDescription, timeDescription)
+
+        if data_ingestion_results is None: return None, None # ingestion returns None if there was an error
+
+        # If we actually got some data, that data should be new and we need to save it in the database.
+        if(data_ingestion_results.data):
+            inserted_series = self.seriesStorage.insert_input(data_ingestion_results)
+            
+            if(inserted_series is None or len(inserted_series.data) == 0): # A sanity check that the data is actually getting inserted!
+                log('WARNING:: A data insertion was triggered but no data was actually inserted!')
+
+        validated_data_ingestion_result = self.__generate_resulting_series(seriesDescription, timeDescription, data_ingestion_results.data)
+        return validated_data_ingestion_result, data_ingestion_results
+    
+
+    def __data_interpolation(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, validated_merged_result: Series) -> tuple[Series]:
+        log(f'Init Interpolation...')
+        # If neither were valid then we attempt to interpolate, checking if we have permissions to do so inside the method
+        integrityClass = data_integrity_factory(seriesDescription.dataIntegrityDescription.call)
+        interpolation_results = integrityClass.exec(validated_merged_result)
+        interpolated_results = self.__generate_resulting_series(seriesDescription, timeDescription, interpolation_results.data)
+    
+        if (not interpolated_results.isComplete):
+                log('WARNING:: Series is not complete after interpolation!')
+        return interpolated_results
 
 
-    def __generate_resulting_series(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, DBList: list[Input], DIList: list[Input] | None = None) -> Series: 
+    def __generate_resulting_series(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, first: list[Input], second: list[Input] | None = None) -> Series: 
         """This function validates a set of results against a request. It will generate a list of every expected time stamp and 
-        attempt to match inputs to those timestamps. If both a database and data ingestion series are provided it will merge them
-        prioritizing results from data ingestion when they conflict with results from the database.
+        attempt to match inputs to those timestamps. If two sets of results are provided it will merge them
+        prioritizing results from from the second when they conflict with results from the first. The intended use is to provide
+        DI results second such that fresh new data overrides old DB data which should be provided first
         :param seriesDescription: SemaphoreSeriesDescription - The request description
         :param timeDescription: TimeDescription - The description of the temporal information of the request 
-        :param DBList: list[Input] - A list of results to validate from the DB
-        :param DIList: list[Input] - A list of results to validate from data ingestion
+        :param first: list[Input] - A list of results to validate.
+        :param second: list[Input] - An optional list of results to merge then validate (NOTE::Likely should be DI results of both DB and DI are being provided)
         :return a validated series: Series
 
         """
         # If there is a verification Override we handle that first and return before the rest of the logic
         if seriesDescription.verificationOverride != None:
-
-            DBList_valid = len(DBList) == seriesDescription.verificationOverride
-            DIList_valid = DIList != None and len(DIList) == seriesDescription.verificationOverride
-
-            valid_list = None
-            if DIList_valid: 
-                valid_list = DIList
-            elif DBList_valid:
-                valid_list = DBList
-
-            if valid_list != None:
-                result = Series(
-                description= seriesDescription, 
-                isComplete= True,
-                timeDescription= timeDescription,
-                )
-                result.data = valid_list
-                return result
-            else:
-                result = Series(
-                description= seriesDescription, 
-                isComplete= False,
-                timeDescription= timeDescription,
-                nonCompleteReason= 'Failed the verification override check.'
-                )
-                return result
-
+            return self.__validate_verification_override(seriesDescription, timeDescription, first, second)
+           
         # Default logic
-
         missing_results = 0
         datetimeList = self.__generate_datetime_list(timeDescription) # A list with every time stamp we expect, with a value of none
         
         # Construct a dictionary of the required date times
         datetimeDict =  { dateTime : None for dateTime in datetimeList }
 
-        # Construct a dictionary for the db results
-        database_results = { input.timeVerified : input for input in DBList }
+        # Construct a dictionary for the first results
+        first_results = { input.timeVerified : input for input in first}
 
-        # If there are data ingestion results construct a dictionary for that too
-        if DIList != None:
-            ingestion_results = { input.timeVerified : input for input in DIList}
-
+        if second != None:# If there are second results construct a dictionary for that too 
+            second_results = { input.timeVerified : input for input in second}
+        else: # If there aren't any we just make an empty dictionary
+            second_results = {}
 
         # Iterate over every timestamp we are expecting 
         for datetime in datetimeDict.keys():
             
-            # If there are results we prioritize the DI result as thats always freshly acquired
-            # If there are no results from either DB or DI, that is missing
-            if DIList != None and ingestion_results.get(datetime):
-                datetimeDict[datetime] = ingestion_results.get(datetime)
-            elif database_results.get(datetime):
-                datetimeDict[datetime] = database_results.get(datetime)
+            # If there are results we prioritize the second list of results
+            # If there are no results from either list, that data point is missing
+            if second_results.get(datetime):
+                datetimeDict[datetime] = second_results.get(datetime)
+            elif first_results.get(datetime):
+                datetimeDict[datetime] = first_results.get(datetime)
             else:
                 missing_results = missing_results + 1
 
@@ -206,6 +208,42 @@ class SeriesProvider():
         )
         result.data = list(datetimeDict.values())
         return result
+    
+    def __validate_verification_override(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, first: list[Input], second: list[Input] | None = None) -> Series:
+        """ There are times when we don't want a series to go through normal verification. A verification override can be used 
+        to use a hard coded value and check a merged series against that value. 
+            NOTE:: This method will always prefer the second series if it is provided! (Ex. New data from data ingestion should be used over old data from the database.)
+        :param seriesDescription: SemaphoreSeriesDescription - The request description.
+        :param timeDescription: TimeDescription - The description of the temporal information of the request .
+        :param first: list[Input] - A list of results to validate.
+        :param second: list[Input] - An optional list of results to merge then validate (NOTE::Likely should be DI results of both DB and DI are being provided)
+        :return a validated series: Series
+        """
+        first_valid = first != None and len(first) == seriesDescription.verificationOverride
+        second_valid = second != None and len(second) == seriesDescription.verificationOverride
+
+        valid_list = None
+        if second_valid: 
+            valid_list = second_valid
+        elif first_valid:
+            valid_list = first_valid
+
+        if valid_list != None:
+            result = Series(
+                description= seriesDescription, 
+                isComplete= True,
+                timeDescription= timeDescription,
+            )
+            result.data = valid_list
+            return result
+        else:
+            result = Series(
+                description= seriesDescription, 
+                isComplete= False,
+                timeDescription= timeDescription,
+                nonCompleteReason= 'Failed the verification override check.'
+            )
+            return result
                 
  
     def __generate_datetime_list(self, timeDescription: TimeDescription) -> list:

--- a/src/SeriesStorage/SS_Classes/TEST_SS.py
+++ b/src/SeriesStorage/SS_Classes/TEST_SS.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+#TEST_SS.py
+#-------------------------------
+# Created By : Matthew Kastl
+# Created Date: 9/3/2024
+# version 1.0
+#-------------------------------
+""" This file is a mock series storage class used to test other parts of SEMAPHORE. 
+To utilize this class you will need to set the env 'ISERIESSTORAGE_INSTANCE' = 'TEST_SS'
+You must also in your request have the data source be 'TEST_SS'
+        NOTE:: YOU MUST CHANGE IT BACK IF THIS CODE IS TO BE TESTED LIVE! 
+The behavior of the functions is determined by what you set the dataSeries to in the description:
+
+    COMPLETE - A series that is correct according to your time description
+    MISS_# - A series is correct but is missing a # of values (Make sure your time description covers enough time ) These values will be randomly selected
+    MISS_FIRST - A series that is correct but missing first value
+    MISS_LAST - A series that is correct but missing last value
+    ERROR_NO_RAISE - Basically just returns None as if the ingestion class encountered an error
+    ERROR_RAISE - Actually will raise an exception for you to catch
+ """ 
+#-------------------------------
+# 
+#
+#Imports
+from SeriesStorage.ISeriesStorage import ISeriesStorage
+from DataClasses import Series, SeriesDescription, SemaphoreSeriesDescription, Input, Output, TimeDescription
+from utility import log
+import random
+
+
+class TEST_SS(ISeriesStorage):
+
+    def __init__(self):
+        log('WARNING:: TEST_SS a testing series storage class just got invoked!')
+ 
+    def select_input(self, seriesDescription: SeriesDescription, timeDescription : TimeDescription) -> Series:
+        if seriesDescription.dataSource != 'TEST_SS': # Make sure we only catch series we are supposed to provide
+            return Series(seriesDescription, False, timeDescription)
+
+        match seriesDescription.dataSeries:
+            case 'COMPLETE': 
+                return self.__make_complete_series(seriesDescription, timeDescription)
+            case 'MISS_FIRST':
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+                series.data = series.data[1:]
+                return series
+            case 'MISS_LAST':
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+                series.data = series.data[:-1]
+                return series
+            case 'ERROR_NO_RAISE':
+                return None
+            case 'ERROR_RAISE':
+                raise Exception
+            case _:
+                isMiss = seriesDescription.dataSeries.find('MISS_') != -1
+                if not isMiss: 
+                    raise Exception(f'{seriesDescription.dataSeries} requested in SS testing class but couldn\'t be understood')
+
+                amount_of_missing = int(seriesDescription.dataSeries[5:])
+                series = self.__make_complete_series(seriesDescription, timeDescription)
+
+                if len(amount_of_missing > len(series.data)):
+                    raise Exception(f'In testing SS class {amount_of_missing} from a series that only has {len(series.data)} values!')
+                
+                series.data = self.__generate_data_with_missing(series.data, amount_of_missing)
+                return series
+
+    
+    def select_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:
+        match semaphoreSeriesDescription.dataSeries:
+            case 'COMPLETE': 
+                return self.__make_complete_series(semaphoreSeriesDescription, timeDescription, False)
+            case 'MISS_FIRST':
+                series = self.__make_complete_series(semaphoreSeriesDescription, timeDescription, False)
+                series.data = series.data[1:]
+                return series
+            case 'MISS_LAST':
+                series = self.__make_complete_series(semaphoreSeriesDescription, timeDescription, False)
+                series.data = series.data[:-1]
+                return series
+            case 'ERROR_NO_RAISE':
+                return None
+            case 'ERROR_RAISE':
+                raise Exception
+            case _:
+                isMiss = semaphoreSeriesDescription.dataSeries.find('MISS_') != -1
+                if not isMiss: 
+                    raise Exception(f'{semaphoreSeriesDescription.dataSeries} requested in SS testing class but couldn\'t be understood')
+
+                amount_of_missing = int(semaphoreSeriesDescription.dataSeries[5:])
+                series = self.__make_complete_series(semaphoreSeriesDescription, timeDescription, False)
+
+                if amount_of_missing > len(series.data):
+                    raise Exception(f'In testing SS class {amount_of_missing} from a series that only has {len(series.data)} values!')
+                
+                series.data = self.__generate_data_with_missing(series.data, amount_of_missing)
+                return series
+    
+    def find_external_location_code(self, sourceCode: str, location: str, priorityOrder: int = 0) -> str:
+        return 'TEST'
+
+    def find_lat_lon_coordinates(self, locationCode: str) -> tuple:
+        return (0, 0)
+    
+    def insert_input(self, series: Series) -> Series:
+        log(f'{len(series.data)} received by ORM to be inserted as inputs')
+        return series
+    
+    def insert_output(self, series: Series) -> Series:
+        log(f'{len(series.data)} received by ORM to be inserted as outputs')
+        return series
+    
+
+    def __generate_data_with_missing(self, data: list[Input], amount_of_missing: int) -> list[Input]:
+        missing_idx = random.sample(range(0, len(data)), amount_of_missing)
+
+        new_data = []
+        for idx, data in enumerate(data):
+            if idx in missing_idx:
+                continue
+            else:
+                new_data.append(data)
+
+        return new_data
+
+            
+    def __make_complete_series(self, seriesDescription: SeriesDescription | SemaphoreSeriesDescription, timeDescription: TimeDescription, isInput: bool = True) -> Series:
+        
+        date_times = self.__generate_datetime_list(timeDescription)
+
+        data = []
+        for datetime in date_times:
+            if isInput:
+                data.append(Input(0, 'TEST', datetime, datetime, 'TEST', 'TEST'))
+            else:
+                data.append(Output(0, 'TEST', datetime,timeDescription.interval))
+
+        series = Series(seriesDescription, False, timeDescription)
+        series.data = data
+        return series
+
+    def __generate_datetime_list(self, timeDescription: TimeDescription) -> list:
+        """This function creates a list of expected time stamps between a from time and a two time at some interval.
+        The keys are the time steps and the values are always set to None.
+        If to time and from time are equal, its only a single pair is returned as that describes a single input.
+        :param timeDescription: TimeDescription - The description of the temporal information of the request 
+        :return list[datetime]
+        """
+        # If to time == from time this is a request for a single point
+        if timeDescription.fromDateTime == timeDescription.toDateTime:
+            return [timeDescription.toDateTime]
+        
+        if timeDescription.interval.total_seconds() == 0:
+            return [timeDescription.toDateTime]
+        
+        # Define the initial time and how many time steps their are.
+        initial_time = timeDescription.fromDateTime
+        steps = int((timeDescription.toDateTime - timeDescription.fromDateTime) / timeDescription.interval)
+        steps = steps + 1 # We increment here as we are inclusive on both sides of the range of datetimes [from time, to time]
+        
+        # GenerateTimeStamp will calculate a timestamp an amount of steps away from the initial time
+        generateTimestamp = lambda initial_time, idx, interval : initial_time + (interval * idx)
+
+        # Perform list comprehension to generate a list of all the time steps we need plus another list of the same size this is all None
+        return [generateTimestamp(initial_time, idx, timeDescription.interval) for idx in range(steps)]
+            
+    

--- a/src/tests/IntegrationTests/test_SeriesProvider.py
+++ b/src/tests/IntegrationTests/test_SeriesProvider.py
@@ -20,33 +20,6 @@ from datetime import datetime, timedelta
 from src.SeriesProvider.SeriesProvider import SeriesProvider, TimeDescription, Series, SeriesDescription, SemaphoreSeriesDescription,Input
 
 
-def test_save_series():
-    """This tests that save series can run with no errors.
-    NOTE::This is a unit test and a proper unit tests can not be made with current framework!
-    """
-    load_dotenv()
-    seriesProvider = SeriesProvider()
-    
-    inputs = [
-    Input(dataValue="20.5", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 0), timeGenerated=datetime(2024, 8, 14, 11, 45)),
-    Input(dataValue="21.0", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 6), timeGenerated=datetime(2024, 8, 14, 11, 51)),
-    Input(dataValue="22.0", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 12), timeGenerated=datetime(2024, 8, 14, 11, 57)),
-    Input(dataValue="19.8", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 18), timeGenerated=datetime(2024, 8, 14, 12, 3)),
-    Input(dataValue="20.0", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 24), timeGenerated=datetime(2024, 8, 14, 12, 9)),
-    Input(dataValue="20.2", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 30), timeGenerated=datetime(2024, 8, 14, 12, 15)),
-    Input(dataValue="19.5", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 36), timeGenerated=datetime(2024, 8, 14, 12, 21)),
-    Input(dataValue="21.3", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 42), timeGenerated=datetime(2024, 8, 14, 12, 27)),
-    Input(dataValue="21.8", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 48), timeGenerated=datetime(2024, 8, 14, 12, 33)),
-    Input(dataValue="20.7", dataUnit="meter", timeVerified=datetime(2024, 8, 14, 12, 54), timeGenerated=datetime(2024, 8, 14, 12, 39))
-]
-    
-    seriesDescription = SeriesDescription('LIGHTHOUSE', 'pWl', 'PACKER')
-    timeDescription = TimeDescription(datetime(2001, 12, 28), datetime(2001, 12, 28) + timedelta(hours=24))
-    series = Series(seriesDescription, True, timeDescription)
-    series.data = inputs
-    seriesProvider.save_input_series(series)
-    assert True
-
 @pytest.mark.parametrize("seriesDescription, timeDescription", [
     (SeriesDescription('apple', 'pear', 'grape'),TimeDescription(datetime(2001, 12, 28), datetime(2001, 12, 28) + timedelta(hours=24), timedelta(hours=1))), # interval < fromTime - toTime
     (SeriesDescription('apple', 'pear', 'grape'),TimeDescription(datetime(2001, 12, 28), datetime(2001, 12, 28) + timedelta(hours=24), timedelta(hours=24))),               # Time range = fromTime - toTime

--- a/src/tests/UnitTests/test_unit_SeriesProvider.py
+++ b/src/tests/UnitTests/test_unit_SeriesProvider.py
@@ -114,11 +114,11 @@ correct_three_hour_series_middle_changed = [
     (test_series_desc, three_hour_time_desc, correct_three_hour_series_missing_one, correct_three_hour_series_with_duplicate, True), # Missing one from DB, correct DI series w/ Duplicate
     (test_series_desc, three_hour_time_desc, correct_three_hour_series_middle_changed, correct_three_hour_series, True), # Both Series, DI has updated data
 ])
-def test__generate_resulting_series(seriesDescription, timeDescription, DBList, DIList, correctness):
+def test__validate_series(seriesDescription, timeDescription, DBList, DIList, correctness):
 
     # Call the generate resulting series method
     seriesProvider = SeriesProvider()
-    result = seriesProvider._SeriesProvider__generate_resulting_series(seriesDescription, timeDescription, DBList, DIList)
+    result = seriesProvider._SeriesProvider__validate_series(seriesDescription, timeDescription, DBList, DIList)
 
     # Test that the method is correctly validating if the series is correct or not
     assert result.isComplete == correctness

--- a/src/tests/UnitTests/test_unit_SeriesProvider.py
+++ b/src/tests/UnitTests/test_unit_SeriesProvider.py
@@ -13,13 +13,59 @@
 #Imports
 import sys
 sys.path.append('/app/src')
+import os
     
 import pytest
 from datetime import datetime, timedelta
 from src.SeriesProvider.SeriesProvider import SeriesProvider
-from src.DataClasses import TimeDescription, SeriesDescription, Input
+from src.DataClasses import TimeDescription, SeriesDescription, Input, DataIntegrityDescription
+from src.SeriesStorage.ISeriesStorage import series_storage_factory
+from unittest import mock
+
+ONE_POINT = TimeDescription(datetime(2000, 1, 1), datetime(2000, 1, 1),  timedelta(hours=1))
+FIVE_POINTS = TimeDescription(datetime(2000, 1, 1), datetime(2000, 1, 1, 4),  timedelta(hours=1))
+
+TWO_HOUR_LIMIT_INTERPOLATION = DataIntegrityDescription('PandasInterpolation', {'method' : 'linear', 'limit': '7200', 'limit_area': 'inside' })
+TWO_HOUR_LIMIT_EX_AND_IN_TERP = DataIntegrityDescription('PandasInterpolation', {'method' : 'linear', 'limit': '7200', 'limit_area': 'None' })
+
+TEST_DI_DESC = SeriesDescription('TEST_DI', 'COMPLETE', 'TEST', None) #
+TEST_DB_DESC = SeriesDescription('TEST_SS', 'COMPLETE', 'TEST', None) #
+TEST_DI_DESC_MISS_1 = SeriesDescription('TEST_DI', 'MISS_1', 'TEST', None)
+TEST_DI_DESC_W_OVERRIDE_5 = SeriesDescription('TEST_DI', 'COMPLETE', 'TEST', None, None, 5)
+TEST_DI_DESC_W_OVERRIDE_5_MISS_1 = SeriesDescription('TEST_DI', 'MISS_1', 'TEST', None, None, 5)
+TEST_DI_DESC_W_INTERP_MISS_LAST = SeriesDescription('TEST_DI', 'MISS_LAST', 'TEST', None, TWO_HOUR_LIMIT_INTERPOLATION)
+TEST_DI_DESC_W_INTERP_MISS_FIRST_EX = SeriesDescription('TEST_DI', 'MISS_LAST', 'TEST', None, TWO_HOUR_LIMIT_EX_AND_IN_TERP)
+TEST_DI_DESC_W_INTERP_MISS_1 = SeriesDescription('TEST_DI', 'MISS_1', 'TEST', None, TWO_HOUR_LIMIT_EX_AND_IN_TERP)
 
 
+@mock.patch.dict(os.environ, {"ISERIESSTORAGE_INSTANCE": "TEST_SS"})
+@pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
+
+    # Testing correctly detecting good series
+    (TEST_DI_DESC, FIVE_POINTS, True), # Tests a normal 5 hour series where the data should be returned by ingestion
+    (TEST_DB_DESC, FIVE_POINTS, True), # Tests a normal 5 hour series where the data should be returned by DB
+    (TEST_DI_DESC, ONE_POINT, True), # Tests a normal 1 hour series where the data should be returned by ingestion
+    (TEST_DB_DESC, ONE_POINT, True), # Tests a normal 1 hour series where the data should be returned by DB
+
+    # Testing correctly detecting missing data
+    (TEST_DI_DESC_MISS_1, FIVE_POINTS, False), # Tests a normal 5 hour series where the data should have one missing from ingestion
+    (TEST_DI_DESC_MISS_1, ONE_POINT, False), # Tests a normal 1 hour series where the data should have one missing from ingestion
+
+    # Testing verification override
+    (TEST_DI_DESC_W_OVERRIDE_5, FIVE_POINTS, True), # Tests a normal 5 hour series where the data is validated with an override
+    (TEST_DI_DESC_W_OVERRIDE_5_MISS_1, FIVE_POINTS, False), # Tests a normal 5 hour series where the data is validated with an override but a value is missing
+
+    # Testing Interpolation
+    (TEST_DI_DESC_W_INTERP_MISS_LAST, FIVE_POINTS, False), # Testing first and last value when extrapolation is NOT allowed
+    (TEST_DI_DESC_W_INTERP_MISS_FIRST_EX, FIVE_POINTS, True), # Testing first and last value when extrapolation is allowed
+    (TEST_DI_DESC_W_INTERP_MISS_1, FIVE_POINTS, True), # Testing interpolating a random missing value from di
+   
+])
+def test_request_input(seriesDescription: SeriesDescription, timeDescription: TimeDescription, expected_output):
+
+    seriesProvider = SeriesProvider()
+    series = seriesProvider.request_input(seriesDescription, timeDescription)
+    assert series.isComplete == expected_output
 
 
 @pytest.mark.parametrize("timeDescription, expected_output", [


### PR DESCRIPTION
Okay, this started with a bug, that if an ingestion class returned an empty series that Series Provider would try and insert it into the DB causing a weird DB error.

In isolation that's a very simple bug fix, but this is the third bug ive fixed in series provider THIS WEEK. The fact is it had some issues. There were some architecture issues with how data was being handled and inserted and it was just incredibly unreadable and had awful tests.

Thus I refactored it to improve its readability and reworked how series provider sends data to get inserted. I wrote a mock data ingestion class and a mock series storage class and reworked the unit testing for series provider.

To test this (and please run through this with a fine tooth comb less we be back here next week to fix another bug):

1. `docker exec semaphore-core python3 -m pytest` To run the new tests
2. `docker exec semaphore-core python3 src/semaphoreRunner.py -d TestModels/test_dspec.json` run this twice, first to see its hitting both ingestion and then again to see its just getting the data from the DB

If you have comments on documentation or how to make this class more readable i'm all ears!!
