### PR TITLE
Logging NDBC Error

### DIFF
--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -162,7 +162,7 @@ class NDBC(IDataIngestion):
         full_series_inputs = self.__get_NDBC(seriesDescription, timeDescription).data # request the data
 
         if not full_series_inputs:  # check that data has been provided
-            log(f"Error: NDBC returned no data! Likely an NDBC outage.")
+            log(f"Warning: NDBC returned no data! Possibly an NDBC outage.")
             # Noted here as likely being an outage because semaphore has only
             # experienced issues with NDBC for limited periods of time
             # leading us to believe the issue is on NDBC's side.

--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -167,6 +167,9 @@ class NDBC(IDataIngestion):
         four_highest = sorted(input_data)[-4:] # Get the four highest values
         mean_four_max = sum(four_highest) / 4.0
 
+        print(f'length of array we want the last input of: {len(full_series_inputs)}')
+        print(f'full_sries_inputs: {full_series_inputs}')
+
         # we return a series with a single input
         last_input = full_series_inputs[-1]
         input = Input(

--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -19,6 +19,7 @@ import re
 from SeriesStorage.ISeriesStorage import series_storage_factory
 from DataClasses import Series, SeriesDescription, Input, TimeDescription
 from DataIngestion.IDataIngestion import IDataIngestion
+from utility import log
 
 class NDBC(IDataIngestion):
 
@@ -154,11 +155,19 @@ class NDBC(IDataIngestion):
         # We expoct the lower method __get_NDBC to save the data in ingests into the database. Then we use that data
         # to compute the four max mean. The issue is the seriesDescription is loaded with the series name as 4mm_XXX
         # and we dont want the lower method to store its data into the db under that name. That would be false.
-        #Thus the lines below switch the name in the seriesDescription, then switch it back after the lower method has run
+        # Thus the lines below switch the name in the seriesDescription, then switch it back after the lower method has run
 
         four_max_series_name = seriesDescription.dataSeries # save old name
         seriesDescription.dataSeries = self.fourMaxMeanConversionDict[seriesDescription.dataSeries] # query the NDBC name
         full_series_inputs = self.__get_NDBC(seriesDescription, timeDescription).data # request the data
+
+        if not full_series_inputs:  # check that data has been provided
+            log(f"Error: NDBC returned no data! Likely an NDBC outage.")
+            # Noted here as likely being an outage because semaphore has only
+            # experienced issues with NDBC for limited periods of time
+            # leading us to believe the issue is on NDBC's side.
+            return None
+        
         seriesDescription.dataSeries = four_max_series_name # switch the name back
 
         # We convert the data from strings to float, sort it, take the four highest, and take their mean

--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -176,9 +176,6 @@ class NDBC(IDataIngestion):
         four_highest = sorted(input_data)[-4:] # Get the four highest values
         mean_four_max = sum(four_highest) / 4.0
 
-        print(f'length of array we want the last input of: {len(full_series_inputs)}')
-        print(f'full_sries_inputs: {full_series_inputs}')
-
         # we return a series with a single input
         last_input = full_series_inputs[-1]
         input = Input(


### PR DESCRIPTION
**Background:** 
For a period of time from late July to mid August semaphore experienced an 'index out of range' error. Because the error has only been observed within that time frame no further investigation was done, however it seemed like a good idea to add a small logging statement for when NDBC returns no data in order to provide future debuggers with more information/context. 

I just did a simple statement and added a comment about why it's likely an error on NDBC's side. Very open to changes that align the log more with what is appropriate to log. 

**To Test:** 
Run a model that uses NDBC to make sure the statement doesn't trigger when data is returned: 
`docker exec semaphore-core python3 src/semaphoreRunner.py -d Inundation/August/ar_inundation_aug_12h.json`

Run a model from the time period the error was observed to ensure log statement executes: 
`docker exec semaphore-core python3 src/semaphoreRunner.py -d Inundation/August/ar_inundation_aug_12h.json -p '202408220101'`