### PR TITLE
latest outputs endpoint

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -85,7 +85,7 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
 @app.get('/output_latest/')
 async def get_outputs_latest(modelNames: list[str] = Query(None)):
     """
-    Queries outputs for a for given models looking for the last prediction that was made with them.
+    Queries outputs for a given models looking for the last prediction that was made with them.
     Args:
         - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
 

--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -10,7 +10,7 @@
 # 
 #
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 
 from datetime import datetime, timedelta
 from DataClasses import SeriesDescription, SemaphoreSeriesDescription, TimeDescription
@@ -77,9 +77,53 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
     )
 
     provider = SeriesProvider()
-    responseSeries = provider.request_input(requestDescription, timeDescription)
+    responseSeries = provider.request_input(requestDescription, timeDescription, saveIngestion=False)
 
     return responseSeries
+
+
+@app.get('/output_latest/')
+async def get_outputs_latest(modelNames: list[str] = Query(None)):
+    """
+    Queries outputs for a for given models looking for the last prediction that was made with them.
+    Args:
+        - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
+
+    Returns:
+        The results for each model index by the model name. If no data can be found for that model the value will be null.
+    """ 
+
+    provider = SeriesProvider()
+    results = {}
+    for modelName in modelNames:
+        results[modelName] = provider.request_output('LATEST', model_name= modelName)
+    return results
+
+
+@app.get('/output_time_span/')
+async def get_outputs_time_span(fromDateTime: str, toDateTime: str, modelNames: list[str] = Query(None)):
+    """
+    Queries outputs for a given time range for given models.
+    Args:
+        - `fromDateTime` (string): "YYYYMMDDHH" Date to start at
+        - `toDateTime` (string): "YYYYMMDDHH" Date to end at
+        - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
+
+    Returns:
+        The results for each model index by the model name. If no data can be found for that model for the provided time range the value will be null.
+    """ 
+    try:
+        fromDateTime = datetime.strptime(fromDateTime, '%Y%m%d%H')
+        toDateTime = datetime.strptime(toDateTime, '%Y%m%d%H')
+    except (ValueError, TypeError, OverflowError) as e:
+        raise HTTPException(status_code=404, detail=f'{e}')
+
+    provider = SeriesProvider()
+    results = {}
+    for modelName in modelNames:
+        results[modelName] = provider.request_output('TIME_SPAN', model_name=modelName, from_time=fromDateTime, to_time=toDateTime)
+    return results
+
 
 
 @app.get('/output/modelName={modelName}/modelVersion={modelVersion}/series={series}/location={location}/fromDateTime={fromDateTime}/toDateTime={toDateTime}')
@@ -136,36 +180,10 @@ async def get_output(modelName: str, modelVersion: str, series: str, location: s
     )
 
     provider = SeriesProvider()
-    responseSeries = provider.request_output(requestDescription, timeDescription)
+    responseSeries = provider.request_output('SPECIFIC', semaphoreSeriesDescription=requestDescription, timeDescription=timeDescription)
 
     return responseSeries
 
-
-@app.get('/latest_outputs/modelName={modelName}/fromDateTime={fromDateTime}/toDateTime={toDateTime}')
-async def get_latest_outputs(modelName: str, fromDateTime: str, toDateTime: str):
-    """
-    Retrieves output series object. It will look for the latest result under the name provided and use that to query the results
-    Args:
-        - `modelName` (string): The name of the model (e.g. "test AI")
-        - `fromDateTime` (string): "YYYYMMDDHH" Date to start at
-        - `toDateTime` (string): "YYYYMMDDHH" Date to end at
-
-    Returns:
-        Series: A Sereies that includes the model information as well as data found within time range or None if no data could be
-        found matching query.
-
-    Raises:
-        HTTPException: If the series is not found.
-    """ 
-    try:
-        fromDateTime = datetime.strptime(fromDateTime, '%Y%m%d%H')
-        toDateTime = datetime.strptime(toDateTime, '%Y%m%d%H')
-    except (ValueError, TypeError, OverflowError) as e:
-        raise HTTPException(status_code=404, detail=f'{e}')
-
-    provider = SeriesProvider()
-    responseData = provider.request_latest_outputs(modelName, fromDateTime, toDateTime)
-    return responseData
 
 @app.get("/health")
 def health_check():

--- a/src/DataIngestion/DI_Classes/SEMAPHORE.py
+++ b/src/DataIngestion/DI_Classes/SEMAPHORE.py
@@ -50,7 +50,7 @@ class SEMAPHORE(IDataIngestion):
         )
 
         # Fetch data through the ORM
-        result = self.series_storage.select_output(ssd, timeDescription)
+        result = self.series_storage.select_specific_output(ssd, timeDescription)
 
         # Repack the data with the original series description and return
         return_series = Series(seriesDescription, True, timeDescription)

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -19,7 +19,7 @@ from exceptions import Semaphore_Ingestion_Exception
 
 from utility import log
 from datetime import timedelta
-
+from datetime import datetime
 
 
 
@@ -93,6 +93,18 @@ class SeriesProvider():
         ###See if we can get the outputs from the database
         requestedSeries = self.seriesStorage.select_output(semaphoreSeriesDescription, timeDescription)
         return requestedSeries
+    
+
+    def request_latest_outputs(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
+        ''' Takes a model name and time range trying to return output results that match. Will try and inferred model information
+            by assuming the latest version.
+            :param model_name: str - The name of the model to query
+            :param to_time: datetime - The latest time to include
+            :param from_time: datetime - The earliest time to include
+        '''
+
+        ###See if we can get the outputs from the database
+        return self.seriesStorage.select_latest_output(model_name, from_time, to_time)
     
 
     def __data_base_query(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> tuple[Series, Series]:

--- a/src/SeriesStorage/ISeriesStorage.py
+++ b/src/SeriesStorage/ISeriesStorage.py
@@ -25,7 +25,15 @@ class ISeriesStorage(ABC):
         raise NotImplementedError()
     
     @abstractmethod
-    def select_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:
+    def select_latest_output(self, model_name: str) -> Series | None: 
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def select_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def select_specific_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:
         raise NotImplementedError()
     
     @abstractmethod
@@ -47,10 +55,7 @@ class ISeriesStorage(ABC):
     @abstractmethod
     def insert_output(self, series: Series) -> Series:
         raise NotImplementedError()
-    
-    @abstractmethod
-    def select_latest_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
-        raise NotImplementedError()
+
 
 def series_storage_factory() -> ISeriesStorage:
     """Imports the series storage class from the environment variable ISERIESSTORAGE_INSTANCE

--- a/src/SeriesStorage/ISeriesStorage.py
+++ b/src/SeriesStorage/ISeriesStorage.py
@@ -47,6 +47,10 @@ class ISeriesStorage(ABC):
     @abstractmethod
     def insert_output(self, series: Series) -> Series:
         raise NotImplementedError()
+    
+    @abstractmethod
+    def select_latest_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
+        raise NotImplementedError()
 
 def series_storage_factory() -> ISeriesStorage:
     """Imports the series storage class from the environment variable ISERIESSTORAGE_INSTANCE

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -167,7 +167,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         outputResult = self.__splice_output([tupleishResult])
 
         # Parse out model information from first output result
-        description = SemaphoreSeriesDescription(tupleishResult[3], tupleishResult[4], tupleishResult[4], tupleishResult[7], tupleishResult[6])
+        description = SemaphoreSeriesDescription(tupleishResult[3], tupleishResult[4], tupleishResult[8], tupleishResult[7], tupleishResult[6])
         series = Series(description, False)
         series.data = outputResult
         return series

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -141,7 +141,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         outputResult = self.__splice_output(tupleishResult)
 
         # Parse out model information from first output result
-        description = SemaphoreSeriesDescription(tupleishResult[0][3], tupleishResult[0][4], tupleishResult[0][4], tupleishResult[0][7], tupleishResult[0][6])
+        description = SemaphoreSeriesDescription(tupleishResult[0][3], tupleishResult[0][4], tupleishResult[0][8], tupleishResult[0][7], tupleishResult[0][6])
         series = Series(description, False)
         series.data = outputResult
         return series

--- a/src/SeriesStorage/SS_Classes/TEST_SS.py
+++ b/src/SeriesStorage/SS_Classes/TEST_SS.py
@@ -169,3 +169,6 @@ class TEST_SS(ISeriesStorage):
 
     def insert_output_and_model_run(self, output_series: Series, execution_time: datetime, return_code: int) -> tuple[Series, dict]:
         raise NotImplementedError()
+    
+    def select_latest_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
+        raise NotImplementedError()

--- a/src/SeriesStorage/SS_Classes/TEST_SS.py
+++ b/src/SeriesStorage/SS_Classes/TEST_SS.py
@@ -68,7 +68,7 @@ class TEST_SS(ISeriesStorage):
                 return series
 
     
-    def select_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:
+    def select_specific_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:
         match semaphoreSeriesDescription.dataSeries:
             case 'COMPLETE': 
                 return self.__make_complete_series(semaphoreSeriesDescription, timeDescription, False)
@@ -166,9 +166,11 @@ class TEST_SS(ISeriesStorage):
         # Perform list comprehension to generate a list of all the time steps we need plus another list of the same size this is all None
         return [generateTimestamp(initial_time, idx, timeDescription.interval) for idx in range(steps)]
             
-
     def insert_output_and_model_run(self, output_series: Series, execution_time: datetime, return_code: int) -> tuple[Series, dict]:
         raise NotImplementedError()
+
+    def select_latest_output(self, model_name: str) -> Series | None: 
+        raise NotImplementedError()
     
-    def select_latest_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
+    def select_output(self, model_name: str, from_time: datetime, to_time: datetime) -> Series | None: 
         raise NotImplementedError()

--- a/src/tests/IntegrationTests/test_SeriesProvider.py
+++ b/src/tests/IntegrationTests/test_SeriesProvider.py
@@ -48,5 +48,5 @@ def test_request_output():
     semaphoreSeriesDescription = SemaphoreSeriesDescription('pineapple', 'strawberry', 'apple', 'pear')
     timeDescription = TimeDescription(datetime(2001, 12, 28), datetime(2001, 12, 28) + timedelta(hours=24))
     series = Series(semaphoreSeriesDescription, True, timeDescription)
-    seriesProvider.request_output(semaphoreSeriesDescription, timeDescription)
+    seriesProvider.request_output('SPECIFIC', semaphoreSeriesDescription=semaphoreSeriesDescription, timeDescription=timeDescription)
     assert True


### PR DESCRIPTION
~~I added a new endpoint called /latest_ouputs its queries outputs based just on a model name and time range, inferring things like model version and lead time based on the latest model version in the db and the latest ouput from that model.~~

~~As a note swaggy ui, what fast api uses for its docs seems to have a bug or something rn, idk I didnt super look into it, but testing through the docs page isn't working. You can use this instead, just make sure you fill it out correctly~~

~~`curl 'http://localhost:8888/semaphore-api/latest_outputs/modelName=ar_inundation_apr_12h/fromDateTime=2024101618/toDateTime=2024101819'  -H 'accept: application/json' -v`~~