### PR TITLE
Adding indexes to 1.0 parser

### DIFF
--- a/src/ModelExecution/dspecParser.py
+++ b/src/ModelExecution/dspecParser.py
@@ -109,6 +109,7 @@ class dspec_sub_Parser_1_0:
 
             keys = []
             types = []
+            indexes = []
             for idx, inputJson in enumerate(inputsJson):
                 dseries = DependentSeries()
                 dseries.name = inputJson["_name"]
@@ -127,6 +128,7 @@ class dspec_sub_Parser_1_0:
                 # We record what is needed for the ordered vector
                 types.append(inputJson["type"])
                 keys.append(str(idx))
+                indexes.append((None, None))
 
                 dependentSeriesList.append(dseries)
             # Bind to dspec
@@ -135,6 +137,7 @@ class dspec_sub_Parser_1_0:
             vOrder = VectorOrder()
             vOrder.keys = keys
             vOrder.dTypes = types
+            vOrder.indexes = indexes
             self.__dspec.orderedVector = vOrder
 
 


### PR DESCRIPTION
I never added indexing to the 1.0 parser it was causing the 1.0 dspecs to fail. This bug patches that, easily testable.

1. Build and run
2. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ThermalRefuge.json`