### PR TITLE
Added cases that handle actual air and water temperature from NOAATANDC

### DIFF
--- a/src/DataIngestion/DI_Classes/NOAATANDC.py
+++ b/src/DataIngestion/DI_Classes/NOAATANDC.py
@@ -55,6 +55,10 @@ class NOAATANDC(IDataIngestion):
                 return self.__fetch_WnSpd(seriesDescription, timeDescription)
             case 'dWnDir':
                 return self.__fetch_WnDir(seriesDescription, timeDescription)
+            case 'dAirTmp':
+                return self.__fetch_dAirTmp(seriesDescription, timeDescription)
+            case 'dWaterTmp':
+                return self.__fetch_dWaterTmp(seriesDescription, timeDescription)
             case _:
                 log(f'Data series: {seriesDescription.dataSeries}, not found for NOAAT&C for request: {seriesDescription}')
                 return None
@@ -360,5 +364,65 @@ class NOAATANDC(IDataIngestion):
 
         series = Series(seriesDescription, True, timeDescription)
         series.data = [input]
+
+        return series
+    
+    def __fetch_dAirTmp(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> None | Series:
+        data, lat_lon = self.__fetch_NOAA_data(seriesDescription, timeDescription, 'air_temperature')
+        if data is None: return None
+
+        inputs = []
+        for idx in data.index:
+
+            # parse
+            dt = idx.to_pydatetime()
+            value = data['v'][idx]
+
+            # If value is not on interval we ignore it
+            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
+                continue
+
+            dataPoints = Input(
+                dataValue= value,
+                dataUnit= 'celsius',
+                timeVerified= dt,
+                timeGenerated= dt, 
+                longitude= lat_lon[1],
+                latitude= lat_lon[0]
+            )
+            inputs.append(dataPoints)
+
+        series = Series(seriesDescription, True, timeDescription)
+        series.data = inputs
+
+        return series
+    
+    def __fetch_dWaterTmp(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> None | Series:
+        data, lat_lon = self.__fetch_NOAA_data(seriesDescription, timeDescription, 'water_temperature')
+        if data is None: return None
+
+        inputs = []
+        for idx in data.index:
+
+            # parse
+            dt = idx.to_pydatetime()
+            value = data['v'][idx]
+
+            # If value is not on interval we ignore it
+            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
+                continue
+
+            dataPoints = Input(
+                dataValue= value,
+                dataUnit= 'celsius',
+                timeVerified= dt,
+                timeGenerated= dt, 
+                longitude= lat_lon[1],
+                latitude= lat_lon[0]
+            )
+            inputs.append(dataPoints)
+
+        series = Series(seriesDescription, True, timeDescription)
+        series.data = inputs
 
         return series

--- a/src/tests/IntegrationTests/test_NOAATANDC.py
+++ b/src/tests/IntegrationTests/test_NOAATANDC.py
@@ -30,7 +30,9 @@ from dotenv import load_dotenv
     ("NOAATANDC", "dXWnCmp000D", "packChan", timedelta(seconds=360), "MHHW"), 
     ("NOAATANDC", "dYWnCmp000D", "packChan", timedelta(seconds=3600), "MHHW"), 
     ("NOAATANDC", "dYWnCmp000D", "packChan", timedelta(seconds=360), "MHHW"), 
-    ("NOAATANDC", "dSurge", "packChan", timedelta(seconds=3600), "MHHW")
+    ("NOAATANDC", "dSurge", "packChan", timedelta(seconds=3600), "MHHW"),
+    ("NOAATANDC", "dAirTmp", "packChan", timedelta(seconds=3600), "MHHW"),
+    ("NOAATANDC", "dWaterTmp", "packChan", timedelta(seconds=3600), "MHHW")
 ])
 
 def test_ingest_series(source: str, series: str, location: str, interval: timedelta, datum: str):
@@ -41,8 +43,8 @@ def test_ingest_series(source: str, series: str, location: str, interval: timede
     load_dotenv()
 
     
-    fromDate = datetime.combine(date(2023, 9, 5), time(11, 0))
-    toDate = datetime.combine(date(2023, 9, 5), time(17, 0))
+    fromDate = datetime.combine(date(2024, 12, 28), time(10, 0))
+    toDate = datetime.combine(date(2024, 12, 28), time(20, 0))
     
     #creating objects to pass
     seriesDescription = SeriesDescription(source, series, location, datum)
@@ -50,5 +52,6 @@ def test_ingest_series(source: str, series: str, location: str, interval: timede
 
     ingestSeries = data_ingestion_factory(seriesDescription)
     resultsSeries = ingestSeries.ingest_series(seriesDescription, timeDescription)
-
+    # Printing the result series with its name and content
+    print(f"Result Series for series '{series}': {resultsSeries.data}")
     assert resultsSeries.isComplete == True

--- a/src/tests/IntegrationTests/test_NOAATANDC.py
+++ b/src/tests/IntegrationTests/test_NOAATANDC.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta, time, date
 from src.DataClasses import Input, Series, TimeDescription, SeriesDescription
 from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from dotenv import load_dotenv
+from utility import log
 
 @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
@@ -53,5 +54,5 @@ def test_ingest_series(source: str, series: str, location: str, interval: timede
     ingestSeries = data_ingestion_factory(seriesDescription)
     resultsSeries = ingestSeries.ingest_series(seriesDescription, timeDescription)
     # Printing the result series with its name and content
-    print(f"Result Series for series '{series}': {resultsSeries.data}")
+    log(f"Result Series for series '{series}': {resultsSeries.data}")
     assert resultsSeries.isComplete == True


### PR DESCRIPTION
This PR adds cases to NOAATANDC that handle actual air and water temperature.

## How to Test:
1. Remove the statement in test_NOAATANDC that skips the test.
2. Run the tests: docker exec semaphore-core python3 -m pytest -s

I added a print statement to show the data. While it may look messy when testing all tests, the ingestion classes are usually skipped anyway. When testing ingestion classes individually, printing the data is helpful to ensure the data is correct.

## Proof of Completion:
The first screenshots are the data from the test and the last 3 screen shots is data from NOAATANDC. This verifies that the correct data is being retrieved from NOAATANDC. Convert from Celsius to Fahrenheit. ATMP is Air Temperature and WTMP is Water Temperature.
![Screenshot 2024-12-28 200813](https://github.com/user-attachments/assets/12c69a62-3834-4b30-9017-a77e3fed7507)
![Screenshot 2024-12-28 200827](https://github.com/user-attachments/assets/7a8308e0-a784-4032-a183-5b2e7e0d379c)
![Screenshot 2024-12-28 200912](https://github.com/user-attachments/assets/9aea841b-86d7-4b39-97e5-1c807c995c65)
![Screenshot 2024-12-28 201107](https://github.com/user-attachments/assets/2cd69676-56ac-4c7b-9812-ad691eb9b846)
![Screenshot 2024-12-28 201321](https://github.com/user-attachments/assets/fffcac45-4e62-4ba8-ad09-005d97317589)

