### PR TITLE
Created CSV file containing the errors that are correlated with the s…

### DIFF
--- a/tools/DatabaseMigration/2_10/2_10_DatabaseMigration.py
+++ b/tools/DatabaseMigration/2_10/2_10_DatabaseMigration.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#2_10_DatabaseMigration.py
+#----------------------------------
+# Created By: Jeremiah Sosa
+# Created Date: 01/03/2025
+# Version 1.0
+#----------------------------------
+"""This is a database migration script that will initialize version
+    2.10 of the database. The change from version 2.9 to 2.10 is that 
+    were adding a reference table to map the error codes.
+ """ 
+#----------------------------------
+# 
+#
+#Imports
+from DatabaseMigration.IDatabaseMigration import IDatabaseMigration
+from sqlalchemy import Table, Column, Integer, String, MetaData, Engine
+from sqlalchemy.dialects.postgresql import insert
+import csv
+
+#Constants
+CSV_FILE_PATHS = './tools/DatabaseMigration/2_10/init_data'
+
+
+class Migrator(IDatabaseMigration):
+
+    def readInitCSV(self, csvFileName: str) -> list:
+        """This function reads in a CSV file
+            :param csvFileName: str - CSV file name
+            
+            :return: Semaphore error codes
+        """
+        csvFilePath = f'{CSV_FILE_PATHS}/{csvFileName}'
+        first_row_error_code = []
+        with open(csvFilePath, mode = 'r') as infile:
+            csv = csv.DictReader(infile)
+            for row in csv:
+                first_row_error_code.append({
+                    "code": int(row['code']),
+                    "result": row['result']
+                })
+
+        return first_row_error_code
+
+    def update(self, databaseEngine: Engine) -> bool:
+        """This function updates the database to version 2.10 which adds the
+           ref_predictionResults table. 
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+        """
+        #create the schema of the additional table 
+        self.__create_schema()
+
+        #first row with error codes
+        first_row_error_codes = self.readInitCSV()
+
+        
+        #starting a transaction
+        with databaseEngine.begin() as connection:
+            #add new table to the database
+            self._metadata.create_all(connection)
+            #insert the first row error codes
+            connection.execute(insert(self.ref_predictionResults)
+                               .values(first_row_error_codes))
+            connection.commit()
+        
+        return True
+
+    def __create_schema(self) -> None:
+        """Builds the db schema for the version table in the metadata.
+        """
+
+        self._metadata = MetaData()
+        
+        #this table stores the current version of the database
+        self.ref_predictionResults = Table(
+            "ref_predictionResults",
+            self._metadata,
+
+            Column("code", Integer, primary_key=True),
+            Column("result", String(32), nullable=False)
+        )
+        
+
+    def rollback(self, databaseEngine: Engine) -> bool:
+        """This function rolls the database back to version 2.9 which involves
+           removing the changes associated with version 2.10.
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+        """
+
+        self.__create_schema()
+        #starting a transaction
+        with databaseEngine.begin() as connection:
+            #dropping the table
+            self.ref_predictionResults.drop(connection)
+
+        return True

--- a/tools/DatabaseMigration/2_10/init_data/errorCodes.csv
+++ b/tools/DatabaseMigration/2_10/init_data/errorCodes.csv
@@ -1,0 +1,5 @@
+code, result
+0, success
+-1, missing data error
+1, ingestion error
+2, semaphore error


### PR DESCRIPTION
Semaphore exit codes and also created 2.10 database migration which should map them accordingly in the reference table, might be wrong though.

**Test**
- Build containers
- Migrate DB to version 2.10
- Roll back to 2.9 version
- Delete the volume 
- Migrate DB to 2.10