### PR TITLE
508 semaphore api returns internal server error when attempting to fetch inputs for flare graph

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -81,14 +81,9 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
     responseSeries = provider.request_input(requestDescription, timeDescription, saveIngestion=False)
 
     # Change the nans in the responseSeries to Nones because fast api's jsonable_encoder cannot handle nans
-    print(f"Checking for Nans in the resposne series")
     for value in responseSeries.data:
-        print(f"Value: {value.dataValue}")
-        print(f"Value Type: {type(value.dataValue)}")
         if np.isnan(value.dataValue): 
-            print(f"The value is a nan: {value.dataValue}")
             value.dataValue = None
-            print(f"The value is now a None: {value.dataValue}")
 
     return responseSeries
 

--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -11,6 +11,7 @@
 #
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query
+import numpy as np
 
 from datetime import datetime, timedelta
 from DataClasses import SeriesDescription, SemaphoreSeriesDescription, TimeDescription
@@ -78,6 +79,16 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
 
     provider = SeriesProvider()
     responseSeries = provider.request_input(requestDescription, timeDescription, saveIngestion=False)
+
+    # Change the nans in the responseSeries to Nones because fast api's jsonable_encoder cannot handle nans
+    print(f"Checking for Nans in the resposne series")
+    for value in responseSeries.data:
+        print(f"Value: {value.dataValue}")
+        print(f"Value Type: {type(value.dataValue)}")
+        if np.isnan(value.dataValue): 
+            print(f"The value is a nan: {value.dataValue}")
+            value.dataValue = None
+            print(f"The value is now a None: {value.dataValue}")
 
     return responseSeries
 

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -63,23 +63,19 @@ class SeriesProvider():
 
         # If there is a verification override, we have to always request new data, so we can return here
         if validated_DB_results.isComplete and seriesDescription.verificationOverride is None: 
-            log(f"Database Query Result: {validated_DB_results}, Raw DB Results: {raw_DB_results}")
             return validated_DB_results
 
         # Next we start Data Ingestion, to go and get the data we need
         validated_DI_results, raw_DI_results = self.__data_ingestion_query(seriesDescription, timeDescription, saveIngestion)
         if validated_DI_results is not None and validated_DI_results.isComplete: 
-            log(f"Data Ingestion Result: {validated_DI_results}, Raw DI Results: {validated_DI_results.data}")
             return validated_DI_results
         
         # If neither of those in isolation work we try merging them together
         validated_merged_results = self.__validate_series(seriesDescription, timeDescription, raw_DB_results.data, None if raw_DI_results is None else raw_DI_results.data)
         if validated_merged_results.isComplete: 
-            log(f"Data Merged Result: {validated_merged_results}")
             return validated_merged_results
         elif seriesDescription.dataIntegrityDescription is None:
             log(f'INFO:: Series is not complete and interpolation was not granted!')
-            print(f'INFO:: Series is not complete and interpolation was not granted!')
             return validated_merged_results
         
         # If we are allowed to interpolate, we interpolate the data and return that

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -63,19 +63,23 @@ class SeriesProvider():
 
         # If there is a verification override, we have to always request new data, so we can return here
         if validated_DB_results.isComplete and seriesDescription.verificationOverride is None: 
+            log(f"Database Query Result: {validated_DB_results}, Raw DB Results: {raw_DB_results}")
             return validated_DB_results
 
         # Next we start Data Ingestion, to go and get the data we need
         validated_DI_results, raw_DI_results = self.__data_ingestion_query(seriesDescription, timeDescription, saveIngestion)
         if validated_DI_results is not None and validated_DI_results.isComplete: 
+            log(f"Data Ingestion Result: {validated_DI_results}, Raw DI Results: {validated_DI_results.data}")
             return validated_DI_results
         
         # If neither of those in isolation work we try merging them together
         validated_merged_results = self.__validate_series(seriesDescription, timeDescription, raw_DB_results.data, None if raw_DI_results is None else raw_DI_results.data)
         if validated_merged_results.isComplete: 
+            log(f"Data Merged Result: {validated_merged_results}")
             return validated_merged_results
         elif seriesDescription.dataIntegrityDescription is None:
             log(f'INFO:: Series is not complete and interpolation was not granted!')
+            print(f'INFO:: Series is not complete and interpolation was not granted!')
             return validated_merged_results
         
         # If we are allowed to interpolate, we interpolate the data and return that


### PR DESCRIPTION
### Issue
When attempting to fetch inputs for the measurements displayed on the Laguna Madre the Semaphore API returns an "Internal Server Error". After further investigation we've found that the API is giving: 2025-01-10 13:52:06 semaphore-api   | ValueError: Out of range float values are not JSON compliant when we attempt to return the inputs from series provider to the API as a JSON object. We've found that this is because there are a small number of nans returned in the data and FastAPI's jsonable_encoder
does not allow nans in the jason object that it returns to the user. 

Our solution was to add a check for nans in the API driver and swap the nans into Nones which FastAPI's jsonable_encoder can parse/remove on it's own. Meaning that the response body that the user gets will exclude the timestamps where a nan was found. 

### Test

1. Bring up the containers. 
2. Check that you can get a response body from the request input method. The below screenshot is the use case we were looking at. 
![image](https://github.com/user-attachments/assets/3ff56795-d55f-470a-9ad2-dc0df7de5103)
If you're test gets back the response "Internal Service Error" we need to keep working, but if you get values then we should be set for Flare to get measurements. 