### PR TITLE
Fixed the 2.9 rollback and added a function that deletes rows from mapping

### DIFF
--- a/tools/DatabaseMigration/2_9/2_9_DatabaseMigration.py
+++ b/tools/DatabaseMigration/2_9/2_9_DatabaseMigration.py
@@ -6,7 +6,7 @@
 # Version 1.0
 #----------------------------------
 """This is a database migration script that will initialize version
-    2.9 of the database. The change from version 2.9 to 2.9 will add
+    2.9 of the database. The change from version 2.8 to 2.9 will add
     rows to the locations reference table and the location
     mapping reference table for Cold Stunning air and water temperature Measurements. 
  """ 
@@ -79,23 +79,22 @@ class Migrator(IDatabaseMigration):
             return result
 
     def rollback(self, databaseEngine: Engine) -> bool:
-        """This function rolls the database back to version 2.9 which involves removing the changes 
+        """This function rolls the database back to version 2.8 which involves removing the changes 
            associated with version 2.9.
 
            :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
            :return: bool indicating successful update
         """
-        # Note that we only explicitly include the locations csv here
-        # because a part of the deep_delete protocol of the data locations
-        # table is to delete the location from the mapping table. 
-        fileNames = ['sbiLocations.csv']
-        fileTypes = [KeywordType.DATA_LOCATION]
-
+        dataLocationCode = "lagunamadre"
+        dataSourceCode = "NDFD_EXP"
+        
         # Using the utility helper class to delete any data dependent on the rows added in the 2.9 Migration
         helper = DatabaseDeletionHelper(databaseEngine)
+        
+        try:
+            helper.delete_mapping_row(dataLocationCode, dataSourceCode)
+        except Exception as e:
+            print(f"Failed to delete mapping row: {e}")
 
-        for file, type in zip(fileNames, fileTypes):
-            for rowDict in self.readInitCSV(file):
-                helper.deep_delete_keyword(rowDict["code"], type)
 
         return True

--- a/tools/DatabaseMigration/databaseMigrationUtility.py
+++ b/tools/DatabaseMigration/databaseMigrationUtility.py
@@ -106,6 +106,27 @@ class DatabaseDeletionHelper():
 
         # Write deleted data to file
         self.__deletion_data_dump(result)
+        
+    def delete_mapping_row(self, dataLocationCode: str, dataSourceCode: str):
+        """ A function to delete a SPECEFIC row from the mapping table without deleting rows from any other reference tables.
+            :param: dataLocationCode - str - The dataLocationCode for row to be deleted.
+            :param: dataSourceCode - str - The dataSourceCode for row to be deleted.
+            :param: tableName - str - The name of the table we want to delete from.
+        """
+        # Connect to the database and delete reference row
+        with self.__engine.connect() as conn:
+
+            # Reflect the table we want to delete from
+            table = self.__metadata.tables["dataLocation_dataSource_mapping"]
+            
+            # Now delete the reference data rows
+            delete_stmt = delete(table).where((table.c.dataSourceCode == dataSourceCode) & (table.c.dataLocationCode == dataLocationCode)).returning(table)
+            cursor = conn.execute(delete_stmt)
+            result = cursor.fetchall()  
+            conn.commit()
+
+        # Write deleted data to file
+        self.__deletion_data_dump(result)
 
     def __deletion_data_dump(self, result: any): 
         """ A function to write deleted database information to a file for safekeeping. 

--- a/tools/DatabaseMigration/databaseMigrationUtility.py
+++ b/tools/DatabaseMigration/databaseMigrationUtility.py
@@ -111,7 +111,6 @@ class DatabaseDeletionHelper():
         """ A function to delete a SPECEFIC row from the mapping table without deleting rows from any other reference tables.
             :param: dataLocationCode - str - The dataLocationCode for row to be deleted.
             :param: dataSourceCode - str - The dataSourceCode for row to be deleted.
-            :param: tableName - str - The name of the table we want to delete from.
         """
         # Connect to the database and delete reference row
         with self.__engine.connect() as conn:


### PR DESCRIPTION
I added a function that specifically deletes rows from mapping without deleting rows from other reference tables. It uses both dataLocation and dataSource since there are many locations with the same name, but different sources.

## How to test (Make sure you start at version 2.9):

Step 1: Build the docker containers
         - `docker compose down`
         - `docker compose build`
         - `docker compose up -d`

Step 2: Open pgadmin and check the datasource_datalocation_mapping table. If you are on version 2.9 there will be a lagunamadre - NDFD_EXP mapping. at the bottom.
![Screenshot 2025-01-22 133154](https://github.com/user-attachments/assets/6aad7383-4d92-434a-80eb-2d2da04943d8)

Step 3: Change the target version in Semaphore to 2.8 to test roll back from 2.9 to 2.8 

Step 4: Build the docker containers

Step 5: Run this command: `docker exec semaphore-core python3 ./tools/migrate_db.py`

Step 6: Close the datasource_datalocation_mapping table tab that you have open and refresh the database. 
           - Right click the database to refresh
           
Step 7: Check the table again and the mapping should be gone

![Screenshot 2025-01-22 132944](https://github.com/user-attachments/assets/c2e02191-5774-440c-a616-1b6b8bd3d6ff)

