### PR TITLE
523 prediction requests in ndfd throw xml error when dates are in the past

### DIFF
--- a/src/DataIngestion/DI_Classes/NDFD_EXP.py
+++ b/src/DataIngestion/DI_Classes/NDFD_EXP.py
@@ -60,9 +60,7 @@ class NDFD_EXP(IDataIngestion):
 
         sleep(30)
 
-        validation_result = date_validation(timeDescription)
-        if not validation_result:
-            return
+        date_validation(timeDescription)
 
         # Remove digits 
         processed_series = re.sub('\d', '', seriesDescription.dataSeries)
@@ -445,9 +443,8 @@ def date_validation(timeDescription : TimeDescription) -> bool:
 
     now = datetime.now().replace(minute=0, second=0, microsecond=0)
 
-    if from_datetime < now or to_datetime < now:
-        log("ERROR: Invalid Date Time Provided. API request not granted.")
-        log(f'From Time:{from_datetime} To Time:{to_datetime}')
-        return False
-    
-    return True
+    try:
+        if from_datetime < now or to_datetime < now:
+            raise ValueError(f'Invalid Date Time Provided. Ingestion request cannot execute')
+    except Exception as err:
+        log(f'Unexpected error occured: {err} (could be an API or ingestion model)')

--- a/src/DataIngestion/DI_Classes/NDFD_EXP.py
+++ b/src/DataIngestion/DI_Classes/NDFD_EXP.py
@@ -34,6 +34,7 @@ from DataIngestion.IDataIngestion import IDataIngestion
 from DataClasses import Series, SeriesDescription, Input, TimeDescription
 from SeriesStorage.ISeriesStorage import series_storage_factory
 from utility import log
+from exceptions import Semaphore_Ingestion_Exception
 import re
 import traceback
 import os
@@ -443,8 +444,7 @@ def date_validation(timeDescription : TimeDescription) -> bool:
 
     now = datetime.now().replace(minute=0, second=0, microsecond=0)
 
-    try:
-        if from_datetime < now or to_datetime < now:
-            raise ValueError(f'Invalid Date Time Provided. Ingestion request cannot execute')
-    except Exception as err:
-        log(f'Unexpected error occured: {err} (could be an API or ingestion model)')
+    if from_datetime < now or to_datetime < now:
+        raise Semaphore_Ingestion_Exception(f'Invalid Date Time Provided. Ingestion request cannot execute')
+    
+    

--- a/src/DataIngestion/DI_Classes/NDFD_EXP.py
+++ b/src/DataIngestion/DI_Classes/NDFD_EXP.py
@@ -60,9 +60,8 @@ class NDFD_EXP(IDataIngestion):
 
         sleep(30)
 
-        time_check_result = __date_time_check(timeDescription)
-        print(f"result = {time_check_result}")
-        if not time_check_result:
+        validation_result = date_validation(timeDescription)
+        if not validation_result:
             return
 
         # Remove digits 
@@ -439,17 +438,16 @@ def iso8601_to_unixms(timestamp: str) -> int:
     except (ValueError, TypeError, AttributeError, OSError) as e:
         raise ValueError(f"Error converting timestamp to milliseconds: {e}")
     
-def __date_time_check(timeDescription : TimeDescription) -> bool:
+def date_validation(timeDescription : TimeDescription) -> bool:
     """Checks if date time passed is valid"""
-
     to_datetime = timeDescription.toDateTime
-    print(f"to date time is : {to_datetime}")
     from_datetime = timeDescription.fromDateTime
-    print(f"from date time is : {from_datetime}")
 
-    now = datetime.now()
-    if (from_datetime <= now) or (to_datetime <= now):
-        log("ERROR: Invalid Date Time Provided")
+    now = datetime.now().replace(minute=0, second=0, microsecond=0)
+
+    if from_datetime < now or to_datetime < now:
+        log("ERROR: Invalid Date Time Provided. API request not granted.")
+        log(f'From Time:{from_datetime} To Time:{to_datetime}')
         return False
     
     return True

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -30,13 +30,18 @@ class Semaphore_Ingestion_Exception(BaseException):
     def __init__(self, message: str):
 
         exc_type, exc_obj, exc_tb = sys.exc_info()
-        fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-        header = f'{exc_type} {fname} {exc_tb.tb_lineno}'
-        traceback = format_exc()
+        
+        if exc_tb:
+            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+            header = f'{exc_type} {fname} {exc_tb.tb_lineno}'
+            traceback_msg = format_exc()
+        else:
+            header = "No active exception"
+            traceback_msg = ''
 
         self.error_code = 1
-        self.message = f'{message}\n{header}\n{traceback}'
-        super().__init__(message)
+        self.message = f'{message}\n{header}\n{traceback_msg}'
+        super().__init__(self.message)
     
     def __str__(self) -> str:
         return f'Error Code: {self.error_code} {self.message}'


### PR DESCRIPTION
This addition will add a function that validates the time passed to NDFD_EXP.

How to test:
- Build containers
- Use this URL to test that the function returns false if either datetimes are in the past: http://localhost:8888/docs