### PR TITLE
Refactoring logging to be independent of cron nor dependent on a sing…

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -8,9 +8,13 @@ DSPEC_FOLDER_PATH= /app/data/dspec/
 REPOSITORY_DSPEC_FOLDER_PATH= /data/dspec/
 MODEL_FOLDER_PATH= /app/data/models/
 INIT_DATA_FOLDER_PATH= /app/data/init_data/
+LOG_BASE_PATH = /app/data/logs # This is the path where the logs will be stored, it needs to be in a mounted volume!
+
 DB_HOST_PORT=5435
 API_HOST_PORT=8888
 
 DISCORD_NOTIFY= 0
 DISCORD_WEBHOOK_PROD= 
 DISCORD_WEBHOOK_DEV= 
+
+

--- a/src/semaphoreRunner.py
+++ b/src/semaphoreRunner.py
@@ -23,7 +23,7 @@ from discord import Discord_Notify
 from DataClasses import Series, SemaphoreSeriesDescription, Output
 from ModelExecution.modelWrapper import ModelWrapper
 from ModelExecution.inputGatherer import InputGatherer
-from utility import log, construct_true_path
+from utility import log, construct_true_path, LogLocationDirector
 from SeriesStorage.ISeriesStorage import series_storage_factory
 
 
@@ -92,6 +92,7 @@ def run_semaphore(fileName: str, executionTime: datetime = None, toss: bool = Fa
             model_name = input_gatherer.get_dspec().modelName
             MW = ModelWrapper(input_gatherer)
 
+            LogLocationDirector().set_log_target_path(getenv('LOG_BASE_PATH'), model_name)
             log(f'----Running {fileName} for {executionTime}! Toss: {toss}----')
 
 

--- a/src/utility.py
+++ b/src/utility.py
@@ -14,7 +14,48 @@
 from datetime import datetime
 from os.path import isabs
 from os import getcwd
+from os import makedirs
+from os.path import dirname, exists
 
+
+
+class LogLocationDirector(object):
+	"""A singleton class that manages the location of the log file.
+	The logger will always reference this signleton to determine where to write
+	the log file. If the path does not exist it will create it. 
+	"""
+
+	_log_target_path = None
+
+	def __new__(cls):
+		"""A singleton constructor that ensures only one instance of the class"""
+		if not hasattr(cls, 'instance'):
+			cls.instance = super(LogLocationDirector, cls).__new__(cls)
+		return cls.instance
+	
+	@property
+	def log_target_path(self) -> str:
+		return self._log_target_path
+	
+	
+	def set_log_target_path(self, log_base_path: str, model_name: str) -> None:
+		"""A setter method that constructs the path to the log file. 
+
+		Note:: We can't use the traditional setter because we want to pass two things.
+		Parameters:
+		---
+		log_base_path - String
+			The base path to the log files.
+		model_name - String
+			The model name from the DSPEC.
+		"""
+
+		directory = f"{log_base_path}/{model_name}/"
+		if not exists(directory):
+			makedirs(directory)
+
+		now = datetime.now()
+		self._log_target_path = f'{directory}{now.year}_{now.month}_{model_name}.log'
 
 
 def get_time_stamp() -> None:
@@ -22,9 +63,10 @@ def get_time_stamp() -> None:
 	timestamp = datetime.now()
 	return timestamp.strftime("%d%m%Y_%H-%M")
 
+
 def log(text: str) -> None:
 	"""An stdout wrapper that prints a message to stdout and to a log file.
-	
+	Will only write to log file if LogLocationDirector has been set.
 	Parameters
 	-------
 	text - String
@@ -32,7 +74,15 @@ def log(text: str) -> None:
 	"""
 	now = datetime.now()
 	timeStamp = now.strftime("%x %X")
-	print(f'{timeStamp}: {text}')
+	msg = f'{timeStamp}: {text}'
+	print(msg) #stdout
+
+	# Write to log file.
+	log_file = LogLocationDirector().log_target_path
+	if log_file is not None:
+		with open(log_file, 'a') as log_file:
+			log_file.write(f'{msg}\n')
+
 
 def construct_true_path(path: str) -> str:
 	"""A method to determin if a given path is a relative or abolute path. If


### PR DESCRIPTION
# Ticket Explanation
I refactored logging to be non cron dependent and splits logs when multiple models are run.

- I created a singleton class to bridge semaphore_runner needing to be able to set the logging location and me not wanting to refactor every point where we called the log method. The log method will always reference the singleton.
- I set the log base path as an enviroment variable. It will always need to be in a mounted directory as Semaphore is running inside a container and we need the logs outside. I set it in the ./data (./app/data) directory as its already a mounted volume. The env will need to be set on deployment.

# To Test
1. Build containers
2. Run multiple models ` docker exec semaphore-core python3 src/semaphoreRunner.py -d MLP-OP.json ./Inundation/March/ar_inundation_mar_12h.json`
3. Look in your `./data` directory **(Not in the container)** and you should see two different log files formatted correctly in the correct folders.
