### PR TITLE
563 refactor dspec again to have numberensablemembers in the input vector

### DIFF
--- a/data/dspec/TestModels/test_multiVector.json
+++ b/data/dspec/TestModels/test_multiVector.json
@@ -1,0 +1,166 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "test_multiVector",
+    "modelVersion": "1.0.0",
+    "author": "John Doe",
+    "modelFileName": "test_AI",
+    "timingInfo":{
+        "active": false,
+        "offset": 0,
+        "interval": 3600
+
+    },
+    "outputInfo": {
+        "outputMethod": "OnePackedFloat",
+        "leadTime": 86400,
+        "series": "testSeries",
+        "location": "PortLavaca",
+        "interval" : 3600, 
+        "datum": "test_datum",
+        "unit" : "meter"
+    },
+    "dependentSeries": [
+        { 
+            "_name": "WindSpeed",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWnSpd",
+            "unit": "meter",
+            "interval": 3600,
+            "range": [0, 0],
+            "outKey": "WindSpd_01"
+            
+            
+        },
+        {
+            "_name": "Wind Direction",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWnDir",
+            "unit": "degrees",
+            "interval": 3600,
+            "range": [0, 0],
+            "outKey": "WindDir_01"
+            
+
+        },
+        {
+            "_name": "Wind Speed",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWnSpd",
+            "unit": "meter",
+            "interval": 3600,
+            "range": [0, -11],
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit":"3600",
+                    "method":"linear",
+                    "limit_area":"inside"      
+                }
+            },
+            "outKey": "WindSpd_12"
+        },
+        {
+            "_name": "Wind Direction",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWnDir",
+            "unit": "degrees",
+            "interval": 3600,
+            "range": [0, -11],
+            "dataIntegrityCall": {
+                "call": "AngleInterpolation",
+                "args": {
+                    "limit":"3600",
+                    "method":"linear",
+                    "limit_area":"inside"  
+                }
+            },
+            "outKey": "WindDir_12"
+        },
+        {
+            "_name": "Wind Speed",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWnSpd",
+            "unit": "meter",
+            "interval": 3600,
+            "range": [0, -12],
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit":"3600",
+                    "method":"linear",
+                    "limit_area":"inside"    
+                }
+            },
+            "outKey": "WindSpd_13"
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ResolveVectorComponents",
+            "args": {
+                "offset": 0,
+                "targetMagnitude_inKey":"WindSpd_01",
+                "targetDirection_inKey":"WindDir_01",
+                "x_comp_outKey": "dXWnCmp000D_1hr", 
+                "y_comp_outKey": "dYWnCmp000D_1hr"      
+            }
+        },
+        {
+            "call": "ResolveVectorComponents",
+            "args": {
+                "offset": 0,
+                "targetMagnitude_inKey":"WindSpd_12",
+                "targetDirection_inKey":"WindDir_12",
+                "x_comp_outKey": "dXWnCmp000D_12hr", 
+                "y_comp_outKey": "dYWnCmp000D_12hr"      
+            }
+        }
+    ],
+    "vectorSpecifications":{
+        "multipliedKeys": ["Key_1","Key_2"],
+        "amntExpectedVectors": 100
+    },
+    "vectorOrder": [
+        {
+            "key": "dXWnCmp000D_1hr",
+            "dType": "float"
+        },
+        {
+            "key": "dYWnCmp000D_1hr",
+            "dType": "float"
+        },
+        {
+            "key": "dXWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "dYWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "dXWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "dYWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "dXWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "dYWnCmp000D_12hr",
+            "dType": "float"
+        },
+        {
+            "key": "WindSpd_13",
+            "dType": "float"
+        }
+    ]
+}

--- a/data/dspec/TestModels/test_multiVector.json
+++ b/data/dspec/TestModels/test_multiVector.json
@@ -121,14 +121,12 @@
             }
         }
     ],
-    "vectorSpecifications":{
-        "multipliedKeys": ["Key_1","Key_2"],
-        "amntExpectedVectors": 100
-    },
     "vectorOrder": [
         {
             "key": "dXWnCmp000D_1hr",
-            "dType": "float"
+            "dType": "float",
+            "multipliedKeys": ["Key_1","Key_2"],
+            "ensembleMemberCount": 100
         },
         {
             "key": "dYWnCmp000D_1hr",

--- a/src/ModelExecution/dspecParser.py
+++ b/src/ModelExecution/dspecParser.py
@@ -110,6 +110,9 @@ class dspec_sub_Parser_1_0:
             keys = []
             types = []
             indexes = []
+            multipliedKeys = []
+            amntExpectedVectors = []
+            
             for idx, inputJson in enumerate(inputsJson):
                 dseries = DependentSeries()
                 dseries.name = inputJson["_name"]
@@ -129,6 +132,9 @@ class dspec_sub_Parser_1_0:
                 types.append(inputJson["type"])
                 keys.append(str(idx))
                 indexes.append((None, None))
+                multipliedKeys.append(None)
+                amntExpectedVectors.append(None)
+                
 
                 dependentSeriesList.append(dseries)
             # Bind to dspec
@@ -138,6 +144,8 @@ class dspec_sub_Parser_1_0:
             vOrder.keys = keys
             vOrder.dTypes = types
             vOrder.indexes = indexes
+            vOrder.multipliedKeys = multipliedKeys
+            vOrder.amntExpectedVectors = amntExpectedVectors
             self.__dspec.orderedVector = vOrder
 
 
@@ -241,24 +249,33 @@ class dspec_sub_Parser_2_0:
     def __parse_vector_order(self):
 
         vOrder: list['dict'] = self.__dspec_json["vectorOrder"]
+        vSpecifications = self.__dspec_json.get("vectorSpecifications", {})
         keys = []
         dTypes = []
         indexes = []
+        
+        
         for dict in vOrder:
             keys.append(dict['key'])
             dTypes.append(dict['dType'])
             
             index: list[int] | None  = dict.get('indexes')
 
-            # If there was no index object we will use None None to index the whole series
+            # If there is no index object we will use None None to index the whole series
             if index is None: indexes.append((None, None))
             else: indexes.append(tuple(index))
+
+        multipliedKeys: list[str] = vSpecifications.get("multipliedKeys", [])
+        amntExpectedVectors: int | None = vSpecifications.get("amntExpectedVectors", None)
 
         vectorOrder = VectorOrder()
         vectorOrder.keys = keys
         vectorOrder.dTypes = dTypes
         vectorOrder.indexes = indexes
+        vectorOrder.multipliedKeys = multipliedKeys
+        vectorOrder.amntExpectedVectors = amntExpectedVectors
         self.__dspec.orderedVector = vectorOrder
+        
 
             
 class Dspec:
@@ -350,12 +367,14 @@ class VectorOrder:
         self.keys = []
         self.dTypes = []
         self.indexes = []
+        self.multipliedKeys = []
+        self.amntExpectedVectors = None
 
     def __str__(self) -> str:
-        return f'\n[VectorOrder] -> keys: {self.keys}, dTypes: {self.dTypes}, indexes: {self.indexes}'
+        return f'\n[VectorOrder] -> keys: {self.keys}, dTypes: {self.dTypes}, indexes: {self.indexes}, multipliedKeys: {self.multipliedKeys}, amntExpectedVectors: {self.amntExpectedVectors}'
     
     def __repr__(self):
-        return f'\nVectorOrder({self.keys}, {self.dTypes}, {self.indexes})'
+        return f'\nVectorOrder({self.keys}, {self.dTypes}, {self.indexes}, {self.multipliedKeys}, {self.amntExpectedVectors})'
     
 
 class TimingInfo:
@@ -370,5 +389,6 @@ class TimingInfo:
     
     def __repr__(self):
         return f'\nTimingInfo({self.offset},{self.interval})'
+    
     
     

--- a/src/tests/UnitTests/test_dspecParser.py
+++ b/src/tests/UnitTests/test_dspecParser.py
@@ -22,7 +22,8 @@ from src.ModelExecution.inputGatherer import InputGatherer
 
 @pytest.mark.parametrize("dspecFilePath", [
      ('./data/dspec/TestModels/test_dspec.json'),
-     ('./data/dspec/TestModels/test_dspec-2-0.json')
+     ('./data/dspec/TestModels/test_dspec-2-0.json'),
+     ('./data/dspec/TestModels/test_multiVector.json')
 ])
 def test_parseDSPEC(dspecFilePath: str):
     """This function tests whether the specified DSPEC file
@@ -139,6 +140,10 @@ def sub_test_dspec_2_0(inputGatherer: InputGatherer, dspecFilePath: str):
         assert vectorOrder.keys[0] == vectorOrderJson[0]["key"]
         assert vectorOrder.dTypes[0] == vectorOrderJson[0]["dType"]
 
+        vectorSpecificationsJson = json.get("vectorSpecifications", {})
+        assert vectorOrder.multipliedKeys == vectorSpecificationsJson.get("multipliedKeys", [])
+        assert vectorOrder.amntExpectedVectors == vectorSpecificationsJson.get("amntExpectedVectors", None)
+        
         # Vector order Count
         assert len(dspec.orderedVector.keys) == 9
         assert len(dspec.orderedVector.dTypes) == 9

--- a/src/tests/UnitTests/test_dspecParser.py
+++ b/src/tests/UnitTests/test_dspecParser.py
@@ -134,15 +134,17 @@ def sub_test_dspec_2_0(inputGatherer: InputGatherer, dspecFilePath: str):
         # Post process Call count
         assert len(dspec.postProcessCall) == 2
 
-        # Vector order (Only the first one)
+        # Vector order 
         vectorOrderJson = json["vectorOrder"]
         vectorOrder = dspec.orderedVector
         assert vectorOrder.keys[0] == vectorOrderJson[0]["key"]
         assert vectorOrder.dTypes[0] == vectorOrderJson[0]["dType"]
-
-        vectorSpecificationsJson = json.get("vectorSpecifications", {})
-        assert vectorOrder.multipliedKeys == vectorSpecificationsJson.get("multipliedKeys", [])
-        assert vectorOrder.amntExpectedVectors == vectorSpecificationsJson.get("amntExpectedVectors", None)
+        
+        # Iterate through vectorOrderJson to ensure all values match
+        for i, entry in enumerate(vectorOrderJson):  
+            assert vectorOrder.multipliedKeys[i] == entry.get("multipliedKeys", [])  # Default to empty list
+            assert vectorOrder.ensembleMemberCount[i] == entry.get("ensembleMemberCount", None)  # Default to None
+   
         
         # Vector order Count
         assert len(dspec.orderedVector.keys) == 9


### PR DESCRIPTION
Changed the variable name as asked  and made sure that only one vector can be an ensemble.
## How to Test:

- Build the containers
- run this command to run tests:  `docker exec semaphore-core python3 -m pytest -s`
- Ensure the dspec parser test passes

