### PR TITLE
3.0 ensembleMemberID column migration

### DIFF
--- a/tools/DatabaseMigration/3_0/3_0_DatabaseMigration.py
+++ b/tools/DatabaseMigration/3_0/3_0_DatabaseMigration.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#3_0_DatabaseMigration.py
+#----------------------------------
+# Created By: Matthew Kastl
+# Created Date: 3/20/2025
+#----------------------------------
+""" This migration adds a new column "ensembleMemberID" to the inputs and outputs tables.
+    It also updates the existing AK constraints to include this new column.
+    This is to support the new ensemble member functionality in the database to keep track
+    of grouped ensemble member data.
+ """ 
+#----------------------------------
+# 
+#
+#Imports
+from DatabaseMigration.IDatabaseMigration import IDatabaseMigration
+from sqlalchemy import Engine, text
+
+
+class Migrator(IDatabaseMigration):
+
+    def update(self, databaseEngine: Engine) -> bool:
+        """ Preform this migration
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+        """
+
+        # For both input and output table
+        # 1. Update table to add "ensembleMemberID" column (default value is null) of type integer
+        # 2. Remove old AK, we aren't allowed to alter it
+        # 3. Add new AK with the new column included
+        inputs_add_emID_col_stmt = text('ALTER TABLE inputs ADD COLUMN "ensembleMemberID" integer')
+        inputs_drop_AK00_stmt = text('ALTER TABLE inputs DROP  CONSTRAINT "inputs_AK00"')
+        inputs_add_AK00_stmt = text("""
+            ALTER TABLE inputs 
+            ADD CONSTRAINT "inputs_AK00" 
+            UNIQUE NULLS NOT DISTINCT (
+                "isActual", 
+                "generatedTime", 
+                "verifiedTime", 
+                "dataUnit", 
+                "dataSource", 
+                "dataLocation", 
+                "dataSeries", 
+                "dataDatum", 
+                "latitude", 
+                "longitude", 
+                "ensembleMemberID" 
+            )
+        """)
+
+        outputs_add_emID_col_stmt = text('ALTER TABLE outputs ADD COLUMN "ensembleMemberID" integer')
+        outputs_drop_AK00_stmt = text('ALTER TABLE outputs DROP  CONSTRAINT "outputs_AK00"')
+        outputs_add_AK00_stmt = text("""
+            ALTER TABLE outputs
+            ADD CONSTRAINT "outputs_AK00" 
+            UNIQUE NULLS NOT DISTINCT (
+                "timeGenerated", 
+                "leadTime", 
+                "modelName", 
+                "modelVersion", 
+                "dataLocation", 
+                "dataSeries", 
+                "dataDatum", 
+                "ensembleMemberID"
+            )
+        """)        
+
+        with databaseEngine.connect() as connection:
+            # input table
+            connection.execute(inputs_add_emID_col_stmt)
+            connection.execute(inputs_drop_AK00_stmt)
+            connection.execute(inputs_add_AK00_stmt)
+
+            # input table
+            connection.execute(outputs_add_emID_col_stmt)
+            connection.execute(outputs_drop_AK00_stmt)
+            connection.execute(outputs_add_AK00_stmt)
+
+            connection.commit()
+        return True
+       
+        
+
+    def rollback(self, databaseEngine: Engine) -> bool:
+        """ Rollback this migration.
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+        """
+
+
+        # For both input and output table
+        # 1. Remove old AK, we aren't allowed to alter it. Ak references the column so
+        #    we need to drop it first i think, it might do it automatically but I dont trust it >:|
+        # 2. Add new AK with the new column removed
+        # 3. Update table to drop "ensembleMemberID" 
+        inputs_drop_AK00_stmt = text('ALTER TABLE inputs DROP  CONSTRAINT "inputs_AK00"')
+        inputs_add_AK00_stmt = text("""
+            ALTER TABLE inputs 
+            ADD CONSTRAINT "inputs_AK00" 
+            UNIQUE NULLS NOT DISTINCT (
+                "isActual", 
+                "generatedTime", 
+                "verifiedTime", 
+                "dataUnit", 
+                "dataSource", 
+                "dataLocation", 
+                "dataSeries", 
+                "dataDatum", 
+                "latitude", 
+                "longitude"
+            )
+        """)
+        inputs_drop_emID_col_stmt = text('ALTER TABLE inputs DROP COLUMN "ensembleMemberID"')
+
+        outputs_drop_AK00_stmt = text('ALTER TABLE outputs DROP  CONSTRAINT "outputs_AK00"')
+        outputs_add_AK00_stmt = text("""
+            ALTER TABLE outputs
+            ADD CONSTRAINT "outputs_AK00" 
+            UNIQUE NULLS NOT DISTINCT (
+                "timeGenerated", 
+                "leadTime", 
+                "modelName", 
+                "modelVersion", 
+                "dataLocation", 
+                "dataSeries", 
+                "dataDatum"
+            )
+        """)  
+        outputs_drop_emID_col_stmt = text('ALTER TABLE outputs DROP COLUMN "ensembleMemberID"')      
+
+        with databaseEngine.connect() as connection:
+            # input table
+            connection.execute(inputs_drop_AK00_stmt)
+            connection.execute(inputs_add_AK00_stmt)
+            connection.execute(inputs_drop_emID_col_stmt)
+
+            # input table
+            connection.execute(outputs_drop_AK00_stmt)
+            connection.execute(outputs_add_AK00_stmt)
+            connection.execute(outputs_drop_emID_col_stmt)
+
+            connection.commit()
+        return True
+        

--- a/tools/DatabaseMigration/target_version.json
+++ b/tools/DatabaseMigration/target_version.json
@@ -1,4 +1,4 @@
 {
-    "Target Version" : "2.12",
-    "Description" : "Removes the artifact in the dataLocation_dataSource_mapping table"
+    "Target Version" : "3.0",
+    "Description" : "Add the ensembleMemberID column and update the AK in inputs and outputs"
 }


### PR DESCRIPTION
This PR updates the DB in a migration script to have the ensembleMemberID in both the inputs and outputs table. It also updates the AK for both tables to include this column.

# To test:

### Test forwards:
```bash
docker compose up --build -d
docker exec semaphore-core python3 tools/migrate_db.py
```
Using PGAdmin you can view the properties of the tables to check their conditions, types, and name

## Test backwards:
Alter `.\tools\DatabaseMigration\target_version.json` to the previous version of 2.12.
```bash
docker compose up --build -d
docker exec semaphore-core python3 tools/migrate_db.py
```

You can also go a step further and run a model to have some data in the DB before you migrate. You will see that all the rows get updated with ensembleMemberID being null (default behavior)