### PR TITLE
Removed $ from lat/long in url

### DIFF
--- a/src/DataIngestion/DI_Classes/TWC.py
+++ b/src/DataIngestion/DI_Classes/TWC.py
@@ -75,7 +75,7 @@ class TWC(IDataIngestion):
 
         # the location the request is for retrieved by checking the locations table in the DB for the location keyword
         lat, lon = self.seriesStorage.find_lat_lon_coordinates(seriesDescription.dataLocation)
-        lat_lon = f'geocode=${lat},${lon}'
+        lat_lon = f'geocode={lat},{lon}'
 
         # We request the prototype feature. 100 members of them.
         num_proto = f'prototypes=temperature:100'


### PR DESCRIPTION
To run:

1. docker compose down
2. docker compose up --build -d
3. go to http://localhost:8888/docs#/default/get_input_input_source__source__series__series__location__location__fromDateTime__fromDateTime__toDateTime__toDateTime__get
4. fill in required fields
5. check the output in dataValue: [...]. Celsius values should be around high 20's and low 30's

I recommend copy and pasting a dataValue block into an AI to find the median and convert it to fahrenheit to see that the temperatures are much higher now. 


![image](https://github.com/user-attachments/assets/4ef4688e-9ac5-49a9-ab2d-dedf0395bd5a)
![image](https://github.com/user-attachments/assets/273a4631-498c-4eb9-9a81-23484658148b)
