### PR TITLE
Removed data manipulation from lighthouse

### DIFF
--- a/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
+++ b/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
@@ -115,8 +115,7 @@ class LIGHTHOUSE(IDataIngestion):
         dataTimestampIndex = 0
         df = get_input_dataFrame()
         for dataPoint in data:
-            
-            # Lighthouse returns epoch time in milliseconds
+         # Lighthouse returns epoch time in milliseconds
             epochTimeStamp = dataPoint[dataTimestampIndex]/1000            # Lighthouse over returns data, so we just clip any data that is before or after our requested date range
             if epochTimeStamp > timeDescription.toDateTime.timestamp() or epochTimeStamp < timeDescription.fromDateTime.timestamp():
                 continue

--- a/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
+++ b/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
@@ -115,12 +115,13 @@ class LIGHTHOUSE(IDataIngestion):
         dataTimestampIndex = 0
         df = get_input_dataFrame()
         for dataPoint in data:
+            
             # Lighthouse returns epoch time in milliseconds
             epochTimeStamp = dataPoint[dataTimestampIndex]/1000            # Lighthouse over returns data, so we just clip any data that is before or after our requested date range
             if epochTimeStamp > timeDescription.toDateTime.timestamp() or epochTimeStamp < timeDescription.fromDateTime.timestamp():
                 continue
 
-            dt = datetime.fromtimestamp(epochTimeStamp, tz=timezone.utc)
+            dt = datetime.fromtimestamp(epochTimeStamp)
 
             df.loc[len(df)] = [
                 dataPoint[dataValueIndex],          # dataValue

--- a/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
+++ b/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
@@ -16,11 +16,10 @@ from DataClasses import Series, SeriesDescription, get_input_dataFrame, TimeDesc
 from DataIngestion.IDataIngestion import IDataIngestion
 from utility import log
 
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.error import HTTPError
 from urllib.request import urlopen
 import json
-from pandas import DataFrame
 
 
 class LIGHTHOUSE(IDataIngestion):
@@ -60,17 +59,17 @@ class LIGHTHOUSE(IDataIngestion):
                 data = json.loads(''.join([line.decode() for line in response.readlines()])) #Download and parse
 
         except HTTPError as err:
-            log(f'Fetch failed, HTTPError of code: {err.status} for: {err.reason}')
+            log(f'Fetch failed, HTTPError of code: {err.status} for: {err.reason}\n URL:[{url}]')
             return None
         except Exception as ex:
-            log(f'Fetch failed, unhandled exceptions: {ex}')
+            log(f'Fetch failed, unhandled exceptions: {ex}\n URL:[{url}]')
             return None
         return data
 
     def __pull_pd_endpoint_dataPoint(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> Series | None:
-        """This function pulls data from LIGHTHOUSE's pd endpoint
+        """This function pulls raw data from LIGHTHOUSE's pd endpoint
         :param seriesRequest: SeriesDescription - A data SeriesDescription object with the information to pull 
-        :param timeREquest: TimeDescription - A data TimeDescription object with the information to pull 
+        :param timeRequest: TimeDescription - A data TimeDescription object with the information to pull 
         :param Series | None: A series containing the imported data or none if something went wrong
 """
         
@@ -103,7 +102,7 @@ class LIGHTHOUSE(IDataIngestion):
         url = f'https://lighthouse.tamucc.edu/pd?stnlist={lighthouseLocationCode}&serlist={seriesInfoMap[SIMSeriesCodeIndex]}&when={fromString}%2C{toString}&whentz=UTC0&-action=app_json&unit=metric&elev={datum}'
         apiReturn = self.__api_request(url)
         if apiReturn == None:
-            log(f'LIGHTHOUSE | __pull_pd_endpoint_dataPoint | For unknown reason fetch failed for {seriesDescription}{timeDescription}')
+            log(f'LIGHTHOUSE | __pull_pd_endpoint_dataPoint | For unknown reason fetch failed for {seriesDescription}{timeDescription}\n URL:[{url}]')
             return None
 
         # Parse Meta Data
@@ -116,21 +115,12 @@ class LIGHTHOUSE(IDataIngestion):
         dataTimestampIndex = 0
         df = get_input_dataFrame()
         for dataPoint in data:
-            if(dataPoint[dataValueIndex] == None): # If lighthouse does not have a requested value, it will return None
-                continue
-            
-            #Filter data via interval if one was provided
             # Lighthouse returns epoch time in milliseconds
-            epochTimeStamp = dataPoint[dataTimestampIndex]/1000
-            if timeDescription.interval != None:
-                if epochTimeStamp % timeDescription.interval.total_seconds() != 0:
-                    continue    
-
-            # Lighthouse over returns data, so we just clip any data that is before or after our requested date range.
+            epochTimeStamp = dataPoint[dataTimestampIndex]/1000            # Lighthouse over returns data, so we just clip any data that is before or after our requested date range
             if epochTimeStamp > timeDescription.toDateTime.timestamp() or epochTimeStamp < timeDescription.fromDateTime.timestamp():
                 continue
 
-            dt = datetime.utcfromtimestamp(epochTimeStamp)
+            dt = datetime.fromtimestamp(epochTimeStamp, tz=timezone.utc)
 
             df.loc[len(df)] = [
                 dataPoint[dataValueIndex],          # dataValue

--- a/src/tests/IntegrationTests/test_LIGHTHOUSE.py
+++ b/src/tests/IntegrationTests/test_LIGHTHOUSE.py
@@ -24,7 +24,7 @@ from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from src.DataIngestion.DI_Classes.LIGHTHOUSE import LIGHTHOUSE
 from dotenv import load_dotenv
 
-# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
 @pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
     # series: dWaterTmp - wtp

--- a/src/tests/IntegrationTests/test_LIGHTHOUSE.py
+++ b/src/tests/IntegrationTests/test_LIGHTHOUSE.py
@@ -24,15 +24,15 @@ from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from src.DataIngestion.DI_Classes.LIGHTHOUSE import LIGHTHOUSE
 from dotenv import load_dotenv
 
-@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
 @pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
     # series: dWaterTmp - wtp
-    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 24), # 1hr interval
+    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 241), # 1hr interval
     (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 11), # 6min interval
     (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 11), # no interval
     # series: dAirTmp - atp
-    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 24), # 1hr interval
+    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 241), # 1hr interval
     (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 11),  # 6min interval
     (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 11), # no interval
     # series: erroneous


### PR DESCRIPTION
## Changes
- Removed dropping nulls
- Removed interval formatting
- Corrected deprecated functions

## How to Test
- Remove line 27 in the Lighthouse test
- docker compose down --volumes
- Build containers: docker compose up --build -d
- docker exec semaphore-core python3 tools/migrate_db.py
- Run Tests: docker exec semaphore-core python3 -m pytest -s
- docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Magnolia/12/magnolia_12.json
NOTE:  Ignore "Can't convert to float: None" error. This is caused by dropping the handling of None in lighthouse.

Make sure this error isnt seen.
<img width="567" height="69" alt="image" src="https://github.com/user-attachments/assets/7ad88801-ec10-4742-9498-2ec49911be1f" />

## Questions
Why did you remove UTC in the timestamp?
- The original function (utcfromtimestamp) returned a UTC timestamp that was timezone-naive. The updated approach (fromtimestamp(..., tz=timezone.utc)) creates a timezone-aware datetime. This mismatch causes errors, since all other DataFrames in the codebase currently use naive datetimes. If we wanted to use  timezone-aware datetimes, we’d need to update multiple files across the project. That change is outside the scope of this ticket, so I just made sure it stayed timezone-naive for consistency.

