### PR TITLE
db migration 3.2

### DIFF
--- a/tools/DatabaseMigration/3_2/3_2_DatabaseMigration.py
+++ b/tools/DatabaseMigration/3_2/3_2_DatabaseMigration.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#3_2_DatabaseMigration.py
+#----------------------------------
+# Created By: Anointiyae Beasley & Matthew Kastl
+# Created Date:09/11/2025
+# Version 1.0
+#----------------------------------
+"""This is a database migration script that will update to version
+    3.2 of the database. The intended change is to make timeGenerated non-nullable, and delete null TimeGenerated rows in inputs
+ """ 
+#----------------------------------
+# 
+#
+#Imports
+from DatabaseMigration.IDatabaseMigration import IDatabaseMigration
+from sqlalchemy import Engine, text
+
+
+#Constants
+CSV_FILE_PATHS = './tools/DatabaseMigration/3_2/init_data'
+
+
+class Migrator(IDatabaseMigration):
+
+    def update(self, databaseEngine: Engine) -> bool:
+        """This function updates the database to version 3.2 which update Source descriptions
+
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+           
+            Updates DB:
+            - Delete rows with null timeGenerated 
+            - Make timeGenerated NOT NULL
+
+        """
+
+        delete_null_timeGenerated_stmt = text('DELETE FROM inputs  WHERE "generatedTime" IS NULL')
+        timeGenerated_not_null_constraint = text('ALTER TABLE inputs ALTER COLUMN "generatedTime" SET NOT NULL')
+
+        with databaseEngine.connect() as connection:
+            # input table
+            connection.execute(delete_null_timeGenerated_stmt)
+            connection.execute(timeGenerated_not_null_constraint)
+
+            connection.commit()
+        return True
+
+
+    def rollback(self, databaseEngine: Engine) -> bool:
+        """This function rolls the database back to version 3.1 which involves removing the changes 
+           associated with version 3.2.
+
+           :param databaseEngine: Engine - the engine of the database we are connecting to (semaphore)
+           :return: bool indicating successful update
+        """
+        rollback_timeGenerated_not_null_constraint = text('ALTER TABLE inputs ALTER COLUMN "generatedTime" DROP NOT NULL')
+
+        with databaseEngine.connect() as connection:
+            # input table
+
+            connection.execute(rollback_timeGenerated_not_null_constraint)
+
+            connection.commit()
+        return True

--- a/tools/DatabaseMigration/target_version.json
+++ b/tools/DatabaseMigration/target_version.json
@@ -1,4 +1,4 @@
 {
-    "Target Version" : "3.1",
-    "Description" : "Add the source TWC"
+    "Target Version" : "3.2",
+    "Description" : "Add null constraint to timeGenerated and delete any null rows"
 }


### PR DESCRIPTION
## Database migration 3.2
 - Deletes null timeGenerated rows ininputs
 - Makes timeGenerated non Null

## How to Test?
- Build containers: `docker compose up --build -d`
- Open pgadmin and take a look at null timeGenerated rows in inputs.
- Right click inputs in pgadmin go to properties and see that timeGenerated does not have Not Null Clicked.
<img width="887" height="246" alt="image" src="https://github.com/user-attachments/assets/3a944a5b-a04d-41b9-8d58-4318c16677dd" />

- Migrate the db: `docker exec semaphore-core python3 ./tools/migrate_db.py`
- Redo 2 and 3. Nulls in timeGenerated should be gone and the Not Null mark should be clicked.

== Roll Back ==
- Change the target version to 3.1
- Build containers: `docker compose up --build -d`
- Migrate db: `docker exec semaphore-core python3 ./tools/migrate_db.py`
- The Not Null Mark shopuld be ticked back off.