### PR TITLE
691 twc sets generated time

### DIFF
--- a/src/DataIngestion/DI_Classes/TWC.py
+++ b/src/DataIngestion/DI_Classes/TWC.py
@@ -150,6 +150,13 @@ class TWC(IDataIngestion):
         unix_validation_timestamps: list[int] = response_data['fcstValid']
         validation_timestamps = [datetime.utcfromtimestamp(ts) for ts in unix_validation_timestamps]
 
+        # Get the generated time (init time)
+        # TWC does not provide a dedicated generated time, so we use the initTime from metadata.
+        # TWC also only provides 1 initTime per request, so we set all rows to the same value.
+        initTime_epoch = response_metadata['initTime']
+        timeGenerated =  datetime.utcfromtimestamp(initTime_epoch)
+
+
         # Get ensemble members shaped (ensemble_member_index, time_index), indexing first value b/c we only requested one prototype (temperature)
         data_buckets: list[list[float]] = response_data['prototypes'][0]['forecast']
         data_buckets: ndarray[float] = np.array(data_buckets).T     # Transpose to (time_index, ensemble_member_index), easier to work with
@@ -162,7 +169,7 @@ class TWC(IDataIngestion):
                 ensemble_data,                      # dataValue (list of values for each ensemble member)
                 'celsius',                          # dataUnit
                 validation_time,                    # timeVerified
-                None,                               # timeGenerated
+                timeGenerated,                      # timeGenerated
                 response_metadata['longitude'],     # longitude
                 response_metadata['latitude']       # latitude
             ]

--- a/src/DataIngestion/DI_Classes/TWC.py
+++ b/src/DataIngestion/DI_Classes/TWC.py
@@ -154,8 +154,7 @@ class TWC(IDataIngestion):
         # TWC does not provide a dedicated generated time, so we use the initTime from metadata.
         # TWC also only provides 1 initTime per request, so we set all rows to the same value.
         initTime_epoch = response_metadata['initTime']
-        timeGenerated =  datetime.utcfromtimestamp(initTime_epoch)
-
+        timeGenerated = datetime.utcfromtimestamp(initTime_epoch)
 
         # Get ensemble members shaped (ensemble_member_index, time_index), indexing first value b/c we only requested one prototype (temperature)
         data_buckets: list[list[float]] = response_data['prototypes'][0]['forecast']

--- a/src/tests/UnitTests/test_TWC.py
+++ b/src/tests/UnitTests/test_TWC.py
@@ -50,7 +50,8 @@ def test_ingest_series_success(mock_urlopen, mock_series_storage_factory, mock_s
     {
         "metadata": {
             "latitude": 40.7128,
-            "longitude": -74.0060
+            "longitude": -74.0060,
+            "initTime": 1735689600
         },
         "forecasts1Hour": {
             "fcstValid": [1697040000, 1697043600],

--- a/src/tests/UnitTests/test_TWC.py
+++ b/src/tests/UnitTests/test_TWC.py
@@ -79,6 +79,11 @@ def test_ingest_series_success(mock_urlopen, mock_series_storage_factory, mock_s
     assert result.dataFrame is not None
     assert len(result.dataFrame) == 2  # Two timestamps in the mocked response
 
+    # check that each row has the same timeGenerated value
+    expected_timeGenerated = datetime.utcfromtimestamp(1735689600)
+    for i in range(len(result.dataFrame)):
+        assert result.dataFrame.iloc[i]['timeGenerated'] == expected_timeGenerated
+
     # Verify the mocked methods were called
     mock_series_storage.find_lat_lon_coordinates.assert_called_once_with("TestLocation")
     mock_urlopen.assert_called_once()


### PR DESCRIPTION
### How it works
TWC does not give an explicit generated time, so we will use initTime extracted from the metadata. Only a single initTime is given, so all rows use the same initTime. This then gets converted using .utcfromtimestamp( ) to get our generatedTime.


### What was changed
- TWC ingestion class now sets generated time as the returned initTime from the response
- updated unit tests to include an initTime key/value pair 
- added an assertion loop to ensure all rows have the same timeGenerated set

### How to test
- `docker compose down`
- `docker compose up --build -d`
- `docker exec semaphore-core python3 -m pytest -v` 
- All tests should pass (except the 2 model_runner assertion tests that fail due to the trailing decimal if you get them).

