### PR TITLE
added upserting to insert inputs

### DIFF
--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -258,11 +258,12 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
                 insertionRows.append(new_row)         
         
         # Insert the rows into the inputs table returning what is inserted as a sanity check
+        # On conflict we update the acquired time to now
         with self.__get_engine().connect() as conn:
             cursor = conn.execute(insert(self.__metadata.tables['inputs'])
-                                    .on_conflict_do_nothing('inputs_AK00')
-                                    .returning(self.__metadata.tables['inputs'])
                                     .values(insertionRows)
+                                    .on_conflict_do_update(constraint='inputs_AK00', set_={"acquiredTime": now})
+                                    .returning(self.__metadata.tables['inputs'])
                                 )
             result = cursor.fetchall()
             conn.commit()


### PR DESCRIPTION
### What was changed 
When there is an AK violation in our inputs table, the row(s) that already exists get their acquiredTime set to now. If there is no AK violation (no already existing row with that same data) then the row gets inserted as normal.

### How to test
1. `docker compose down`
2. `docker compose up --build -d`
3. `docker exec semaphore-core python3 ./tools/migrate_db.py` I'm not sure if this matters, but I did just in case
4. Open PGAdmin and connect to your local DB
5. Select the last 100 rows from the inputs table
6. Run this query to insert a dummy row into the table
`INSERT INTO inputs
("generatedTime", "acquiredTime", "verifiedTime", "dataValue",
     "isActual", "dataUnit", "dataSource", "dataLocation", "dataSeries",
     "dataDatum", "latitude", "longitude", "ensembleMemberID")
VALUES 
('2025-10-01 00:00:00', '2025-10-01 00:00:00', '2025-10-01 00:00:00', 100, true,
'meter', 'LIGHTHOUSE', 'PortLavaca', 'testSeries', 'test_datum', 0.0, 0.0, null)
ON CONFLICT ON CONSTRAINT "inputs_AK00"
DO UPDATE SET "acquiredTime" = EXCLUDED."acquiredTime";`
7. Select the last 100 rows of the input table to make sure the row got added
8. Run the same query but change the acquiredTime.
9. Refreshed the inputs table to make sure the acquired time got updated for the test row
10. Don't forget to delete the test row after you are done in your local db.

### Notes
- Testing with the SQL statement is very similar to what the code does. The only different I see is that the test query used here sets the acquiredTime to whatever you use in the query, while in the actual code we set the updated acquiredTime to now.
- Testing something like this is pretty difficult, so I provided some form of testing rather than no testing at all... If you know any other ways to test this let me know!

### Expected output
Adding the test row after the 1st query:
<img width="2190" height="732" alt="image" src="https://github.com/user-attachments/assets/c69b945b-7e05-4692-8178-26817dabe1fd" />


Updating the acquiredTime after the 2nd query:
<img width="2220" height="540" alt="image" src="https://github.com/user-attachments/assets/44ace66a-99db-4dfd-812d-1e44df50ef5a" />



