### PR TITLE
702 refactor series storage to remove reindexing in selection queries

### DIFF
--- a/src/DataIngestion/DI_Classes/NDBC.py
+++ b/src/DataIngestion/DI_Classes/NDBC.py
@@ -15,11 +15,11 @@ from datetime import datetime
 import requests
 import re
 
-
 from SeriesStorage.ISeriesStorage import series_storage_factory
 from DataClasses import Series, SeriesDescription, get_input_dataFrame, TimeDescription
 from DataIngestion.IDataIngestion import IDataIngestion
 from utility import log
+
 
 class NDBC(IDataIngestion):
 
@@ -127,6 +127,7 @@ class NDBC(IDataIngestion):
 
         df, units = self.__download_NDBC_data(NDBC_location_code)
 
+        # Filter data to requested time range - return all valid data points within range
         df_inTimeRange = df.loc[timeDescription.toDateTime:timeDescription.fromDateTime]
 
         df_result = get_input_dataFrame()
@@ -134,6 +135,7 @@ class NDBC(IDataIngestion):
             dataValue = row[seriesDescription.dataSeries]
             dataUnit = self.unitConversionDict[units[df.columns.get_loc(seriesDescription.dataSeries)]]
             dateTime = dt_idx
+            # Skip missing values (MM in NDBC data)
             if dataValue != 'MM':
                 df_result.loc[len(df_result)] = [
                     dataValue,  # dataValue

--- a/src/DataIngestion/DI_Classes/NDFD.py
+++ b/src/DataIngestion/DI_Classes/NDFD.py
@@ -196,9 +196,6 @@ class NDFD(IDataIngestion):
             df = get_input_dataFrame()
             for row in data_dictionary:
                 timeVerified = datetime.fromtimestamp(row[0])
-                if timeRequest.interval is not None:
-                    if(timeVerified.timestamp() % timeRequest.interval.total_seconds() != 0):
-                        continue
 
                 # NDFD over returns data, so we just clip any data that is before or after our requested date range.
                 if timeVerified > timeRequest.toDateTime or timeVerified < timeRequest.fromDateTime:

--- a/src/DataIngestion/DI_Classes/NDFD_EXP.py
+++ b/src/DataIngestion/DI_Classes/NDFD_EXP.py
@@ -215,10 +215,6 @@ class NDFD_EXP(IDataIngestion):
             df = get_input_dataFrame()
             for row in data_dictionary:
                 timeVerified = datetime.fromtimestamp(row[0])
-                if timeRequest.interval is not None:
-                    if(timeVerified.timestamp() % timeRequest.interval.total_seconds() != 0):
-                        continue
-
 
                 # NDFD over returns data, so we just clip any data that is before or after our requested date range.
                 if timeVerified > timeRequest.toDateTime or timeVerified < timeRequest.fromDateTime:

--- a/src/DataIngestion/DI_Classes/NOAATANDC.py
+++ b/src/DataIngestion/DI_Classes/NOAATANDC.py
@@ -199,10 +199,6 @@ class NOAATANDC(IDataIngestion):
             dt = idx.to_pydatetime()
             value = data['v'][idx]
 
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
-
             df.loc[len(df)] = [
                 value,          # dataValue
                 'meter',        # dataUnit
@@ -242,10 +238,6 @@ class NOAATANDC(IDataIngestion):
             # parse
             dt = idx.to_pydatetime()
             value = data['v'][idx]
-
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
 
             df.loc[len(df)] = [
                 value,                  # dataValue
@@ -297,10 +289,6 @@ class NOAATANDC(IDataIngestion):
             predictive_water_level = pData['v'][idx]
             surge = str(float(water_level) - float(predictive_water_level))
 
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
-
             df.loc[len(df)] = [
                 surge,                  # dataValue
                 'meter',                # dataUnit
@@ -344,10 +332,6 @@ class NOAATANDC(IDataIngestion):
             dt = idx.to_pydatetime()
             wind_dir = data['d'][idx]
 
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
-
             df.loc[len(df)] = [
                 wind_dir,          # dataValue
                 'degrees',        # dataUnit
@@ -387,10 +371,6 @@ class NOAATANDC(IDataIngestion):
             # parse
             dt = idx.to_pydatetime()
             wind_spd = data['s'][idx]
-
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
 
             df.loc[len(df)] = [
                 wind_spd,          # dataValue
@@ -445,10 +425,6 @@ class NOAATANDC(IDataIngestion):
             wind_dir = float(data['d'][idx])
             x_comp = wind_speed * cos(wind_dir - offset)
             y_comp = wind_speed * sin(wind_dir - offset)
-
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
 
             x_df.loc[len(x_df)] = [
                 x_comp,          # dataValue
@@ -550,10 +526,6 @@ class NOAATANDC(IDataIngestion):
             dt = idx.to_pydatetime()
             value = data['v'][idx]
 
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
-
             df.loc[len(df)] = [
                 value,                  # dataValue
                 'celsius',              # dataUnit
@@ -592,10 +564,6 @@ class NOAATANDC(IDataIngestion):
             # parse
             dt = idx.to_pydatetime()
             value = data['v'][idx]
-
-            # If value is not on interval we ignore it
-            if dt.timestamp() % timeDescription.interval.total_seconds() != 0:
-                continue
 
             df.loc[len(df)] = [
                 value,                  # dataValue

--- a/src/DataIngestion/DI_Classes/TWC.py
+++ b/src/DataIngestion/DI_Classes/TWC.py
@@ -20,7 +20,7 @@ from exceptions import Semaphore_Ingestion_Exception
 from numpy import ndarray
 import numpy as np
 
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 from os import getenv
@@ -84,7 +84,7 @@ class TWC(IDataIngestion):
         api_permission = f'apiKey={self.api_key}'
 
         # Ensure the requested time range is not in the past
-        now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+        now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
         if timeDescription.fromDateTime < now:
             raise Semaphore_Ingestion_Exception("ERROR: Requested time range starts in the past. Please provide a valid time range.")
         
@@ -148,13 +148,13 @@ class TWC(IDataIngestion):
 
         # Get the validation times for the data we requested
         unix_validation_timestamps: list[int] = response_data['fcstValid']
-        validation_timestamps = [datetime.utcfromtimestamp(ts) for ts in unix_validation_timestamps]
+        validation_timestamps = [datetime.fromtimestamp(ts, tz=timezone.utc) for ts in unix_validation_timestamps]
 
         # Get the generated time (init time)
         # TWC does not provide a dedicated generated time, so we use the initTime from metadata.
         # TWC also only provides 1 initTime per request, so we set all rows to the same value.
         initTime_epoch = response_metadata['initTime']
-        timeGenerated = datetime.utcfromtimestamp(initTime_epoch)
+        timeGenerated = timeGenerated = datetime.fromtimestamp(initTime_epoch, tz=timezone.utc)
 
         # Get ensemble members shaped (ensemble_member_index, time_index), indexing first value b/c we only requested one prototype (temperature)
         data_buckets: list[list[float]] = response_data['prototypes'][0]['forecast']

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#SQLAlchemyORM.py
+#SQLAlchemyORM_Postgres.py
 #-------------------------------
 # Created By : Matthew Kastl
 # Created Date: 3/26/2023
@@ -30,7 +30,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
  
     def __init__(self) -> None:
         """Constructor generates an a db schema. Automatically creates the 
-        metadata object holding the defined schema.
+            metadata object holding the defined schema.
         """
         self.__create_engine(getenv('DB_LOCATION_STRING'), False)
         self.__metadata = MetaData()
@@ -57,13 +57,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         tupleishResult = self.__dbSelection(statement).fetchall()
         df_inputResult = self.__splice_input(tupleishResult)
         
-        # Prune the results removing any data that does not align with the interval that was requested
-        df_prunedInputs = df_inputResult.copy(deep=True)
-        if timeDescription.interval != None and timeDescription.interval.total_seconds() != 0:
-            for i in range(len(df_inputResult)):
-                if not (df_inputResult.iloc[i]['timeVerified'].timestamp() % timeDescription.interval.total_seconds() == 0):
-                    df_prunedInputs.drop(i, inplace=True)
-
+        # Sending all rows found downstream the input gatherer will handle interval alignment
         series = Series(seriesDescription, True, timeDescription)
         series.dataFrame = df_prunedInputs
         return series

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -59,7 +59,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         
         # Sending all rows found downstream the input gatherer will handle interval alignment
         series = Series(seriesDescription, True, timeDescription)
-        series.dataFrame = df_prunedInputs
+        series.dataFrame = df_inputResult
         return series
     
     def select_specific_output(self, semaphoreSeriesDescription: SemaphoreSeriesDescription, timeDescription : TimeDescription) -> Series:

--- a/src/tests/IntegrationTests/test_LIGHTHOUSE.py
+++ b/src/tests/IntegrationTests/test_LIGHTHOUSE.py
@@ -24,7 +24,7 @@ from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from src.DataIngestion.DI_Classes.LIGHTHOUSE import LIGHTHOUSE
 from dotenv import load_dotenv
 
-# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
 @pytest.mark.parametrize("seriesDescription, timeDescription, expected_min_output", [
     # series: dWaterTmp - wtp
@@ -67,7 +67,7 @@ def test_pull_pd_endpoint_dataPoint(seriesDescription: SeriesDescription, timeDe
                 assert start_time <= row_timestamp <= end_time, f"Data point {row['timeVerified']} is outside requested range"
 
 
-# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
 @pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
     # series: erroneous

--- a/src/tests/IntegrationTests/test_LIGHTHOUSE.py
+++ b/src/tests/IntegrationTests/test_LIGHTHOUSE.py
@@ -3,7 +3,7 @@
 #-------------------------------
 # Created By: Matthew Kastl
 # Created Date: 11/2/2023
-# version 1.0
+# Version: 1.0
 #----------------------------------
 """This file tests the LIGHTHOUSE ingestion class and its functions. 
 
@@ -24,23 +24,26 @@ from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from src.DataIngestion.DI_Classes.LIGHTHOUSE import LIGHTHOUSE
 from dotenv import load_dotenv
 
-@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
-@pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
+@pytest.mark.parametrize("seriesDescription, timeDescription, expected_min_output", [
     # series: dWaterTmp - wtp
+    # Note: After refactor, all valid data points are returned (no interval filtering)
+    # so we expect more data points than before, using minimum expected counts
     (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 24), # 1hr interval
-    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 11), # 6min interval
-    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 11), # no interval
+    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 10), # 1 hour range - expect at least 10 points
+    (SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 10), # 1 hour range - no interval specified
     # series: dAirTmp - atp
-    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 24), # 1hr interval
-    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 11),  # 6min interval
-    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 11), # no interval
+    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), 24), # 1 day range
+    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), timedelta(seconds=360)), 10),  # 1 hour range
+    (SeriesDescription('LIGHTHOUSE', 'dAirTmp', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 6), time(12, 0)), None), 10), # 1 hour range - no interval
     # series: erroneous
     (SeriesDescription('LIGHTHOUSE', 'apple', 'SouthBirdIsland'), TimeDescription(datetime.combine(date(2023, 9, 6), time(11, 0)), datetime.combine(date(2023, 9, 7), time(11, 0)), timedelta(seconds=3600)), None),
 ])
-def test_pull_pd_endpoint_dataPoint(seriesDescription: SeriesDescription, timeDescription: TimeDescription, expected_output: int | None):
+def test_pull_pd_endpoint_dataPoint(seriesDescription: SeriesDescription, timeDescription: TimeDescription, expected_min_output: int | None):
     """This function tests the pull_pd_endpoint_dataPoint which is datapoints from LIGHTHOUSE's pd endpoint
         function is complete.
+        After refactor: Tests that all valid data points within time range are returned (no interval filtering).
         NOTE:: This test depends on DBM.insert_external_location_code('SouthBirdIsland', 'LIGHTHOUSE', '013', 0) pre=existing in db
     """
     load_dotenv()
@@ -48,12 +51,23 @@ def test_pull_pd_endpoint_dataPoint(seriesDescription: SeriesDescription, timeDe
     lighthouse = LIGHTHOUSE()
     result: Series = lighthouse._LIGHTHOUSE__pull_pd_endpoint_dataPoint(seriesDescription, timeDescription)
 
-    if result == None:
-        assert result == expected_output
+    if expected_min_output is None:
+        assert result is None
     else:
-        assert len(result.dataFrame) == expected_output
+        assert result is not None
+        assert len(result.dataFrame) >= expected_min_output
+        
+        # Verify that all returned data points are within the requested time range
+        if len(result.dataFrame) > 0:
+            start_time = timeDescription.fromDateTime.timestamp()
+            end_time = timeDescription.toDateTime.timestamp()
+            
+            for _, row in result.dataFrame.iterrows():
+                row_timestamp = row['timeVerified'].timestamp()
+                assert start_time <= row_timestamp <= end_time, f"Data point {row['timeVerified']} is outside requested range"
 
-@pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
+
+# @pytest.mark.skipif(True, reason="Data Ingestion Classes Tests Run Very Slowly")
 
 @pytest.mark.parametrize("seriesDescription, timeDescription, expected_output", [
     # series: erroneous
@@ -68,4 +82,8 @@ def test_ingest_series(seriesDescription: SeriesDescription, timeDescription: Ti
     lighthouse = data_ingestion_factory(seriesDescription)
     result = lighthouse.ingest_series(seriesDescription, timeDescription)
 
-    assert result == expected_output
+    if expected_output is None:
+        assert result is None
+    elif expected_output == "has_data":
+        assert result is not None
+        assert len(result.dataFrame) > 0

--- a/src/tests/UnitTests/test_NOAATANDC.py
+++ b/src/tests/UnitTests/test_NOAATANDC.py
@@ -17,8 +17,8 @@ from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime, timedelta, time, date
 import pandas as pd
 import numpy as np
-from src.DataClasses import Series, TimeDescription, SeriesDescription
-from src.DataIngestion.NOAATANDC import NOAATANDC
+from DataClasses import Series, TimeDescription, SeriesDescription
+from src.DataIngestion.DI_Classes.NOAATANDC import NOAATANDC
 
 
 class TestNOAATANDCUnit:
@@ -39,7 +39,7 @@ class TestNOAATANDCUnit:
             'd': [45, 50, 40, 55, 35, 60, 30, 65, 70, 25, 20]  # wind direction
         }, index=timestamps)
     
-    @patch('src.DataIngestion.NOAATANDC.series_storage_factory')
+    @patch('src.DataIngestion.DI_Classes.NOAATANDC.series_storage_factory')
     def test_init(self, mock_factory):
         """Test NOAATANDC initialization."""
         mock_storage = Mock()
@@ -66,14 +66,14 @@ class TestNOAATANDCUnit:
         with patch.object(self.noaa_ingester, '_NOAATANDC__seriesStorage') as mock_storage:
             mock_storage.find_external_location_code.return_value = None
             
-            with patch('src.DataIngestion.NOAATANDC.log') as mock_log:
+            with patch('src.DataIngestion.DI_Classes.NOAATANDC.log') as mock_log:
                 result = self.noaa_ingester._NOAATANDC__get_station_number('invalidLocation')
                 
                 assert result is None
                 mock_log.assert_called_once()
                 assert 'Empty dataSource Location mapping received' in mock_log.call_args[0][0]
     
-    @patch('src.DataIngestion.NOAATANDC.Station')
+    @patch('src.DataIngestion.DI_Classes.NOAATANDC.Station')
     def test_fetch_NOAA_data_success(self, mock_station_class):
         """Test successful NOAA API data fetch."""
         # Setup mocks
@@ -97,7 +97,7 @@ class TestNOAATANDCUnit:
             mock_station_class.assert_called_once_with(id='8775792')
             mock_station.get_data.assert_called_once()
     
-    @patch('src.DataIngestion.NOAATANDC.Station')
+    @patch('src.DataIngestion.DI_Classes.NOAATANDC.Station')
     def test_fetch_NOAA_data_single_point(self, mock_station_class):
         """Test NOAA API data fetch for single point in time."""
         # Setup for single point request
@@ -122,7 +122,7 @@ class TestNOAATANDCUnit:
             assert result_data is not None
             assert len(result_data) == 1
     
-    @patch('src.DataIngestion.NOAATANDC.Station')
+    @patch('src.DataIngestion.DI_Classes.NOAATANDC.Station')
     def test_fetch_NOAA_data_api_error(self, mock_station_class):
         """Test NOAA API data fetch with API error."""
         mock_station_class.side_effect = ValueError("Invalid station ID")
@@ -130,7 +130,7 @@ class TestNOAATANDCUnit:
         with patch.object(self.noaa_ingester, '_NOAATANDC__get_station_number') as mock_get_station:
             mock_get_station.return_value = '8775792'
             
-            with patch('src.DataIngestion.NOAATANDC.log') as mock_log:
+            with patch('src.DataIngestion.DI_Classes.NOAATANDC.log') as mock_log:
                 series_desc = SeriesDescription("NOAATANDC", "dWl", "packChan", "MHHW")
                 time_desc = TimeDescription(self.from_date, self.to_date, timedelta(hours=1))
                 
@@ -174,7 +174,7 @@ class TestNOAATANDCUnit:
     
     def test_ingest_series_unsupported(self):
         """Test ingest_series with unsupported series type."""
-        with patch('src.DataIngestion.NOAATANDC.log') as mock_log:
+        with patch('src.DataIngestion.DI_Classes.NOAATANDC.log') as mock_log:
             series_desc = SeriesDescription("NOAATANDC", "unsupportedSeries", "packChan", "MHHW")
             time_desc = TimeDescription(self.from_date, self.to_date, timedelta(hours=1))
             
@@ -236,7 +236,7 @@ class TestNOAATANDCUnit:
             
             assert result is not None
             assert isinstance(result, Series)
-            assert result.seriesDescription.dataDatum == 'NA'
+            assert result.description.dataDatum == 'NA'
             assert all(result.dataFrame['dataUnit'] == 'meter')
             assert mock_fetch.call_count == 2
     

--- a/src/tests/UnitTests/test_TWC.py
+++ b/src/tests/UnitTests/test_TWC.py
@@ -16,7 +16,7 @@ sys.path.append('/app/src')
 
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from DataIngestion.DI_Classes.TWC import TWC
 from DataClasses import SeriesDescription, TimeDescription
 from exceptions import Semaphore_Ingestion_Exception
@@ -31,8 +31,8 @@ def mock_series_description():
 @pytest.fixture
 def mock_time_description():
     mock_td = MagicMock(spec=TimeDescription, autospec=True) 
-    mock_td.configure_mock(fromDateTime=datetime.utcnow() + timedelta(hours=1))
-    mock_td.configure_mock(toDateTime=datetime.utcnow() + timedelta(hours=25))
+    mock_td.configure_mock(fromDateTime=datetime.now(timezone.utc) + timedelta(hours=1))
+    mock_td.configure_mock(toDateTime=datetime.now(timezone.utc) + timedelta(hours=25))
     return mock_td
 
 
@@ -80,7 +80,7 @@ def test_ingest_series_success(mock_urlopen, mock_series_storage_factory, mock_s
     assert len(result.dataFrame) == 2  # Two timestamps in the mocked response
 
     # check that each row has the same timeGenerated value
-    expected_timeGenerated = datetime.utcfromtimestamp(1735689600)
+    expected_timeGenerated = datetime.fromtimestamp(1735689600, tz=timezone.utc)
     for i in range(len(result.dataFrame)):
         assert result.dataFrame.iloc[i]['timeGenerated'] == expected_timeGenerated
 


### PR DESCRIPTION
Really Simple to remove re-indexing, just check that tests still pass while we're in the transition phase and data gather hasn't been refactored yet to handle getting all the available data.  Double check that I didn't miss anything I should have removed please. Will close #702.