### PR TITLE
706 insure api is serializing data objects correctly

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -200,6 +200,7 @@ def serialize_input_series(series: Series) -> dict[any]:
     param: series - Series The input series to serialize.
     return: A dictionary representation of the input series.
 
+    NOTE:: Ensures `isComplete` always exists and is set to True for backward compatibility.
     NOTE:: Expected input series serialization
     {
         "description": {
@@ -236,6 +237,9 @@ def serialize_input_series(series: Series) -> dict[any]:
     # Remove the automatically serialized dataFrame
     del serialized['_Series__dataFrame']
 
+    # Always include isComplete for backward compatibility
+    serialized['isComplete'] = True
+
     # Serialize the dataFrame by our own rules
     serialized_data = []
     for _, row in series.dataFrame.iterrows():
@@ -264,6 +268,7 @@ def serialize_output_series(series: Series) -> dict[any]:
     param: series - Series The output series to serialize.
     return: A dictionary representation of the output series.
 
+    NOTE:: Ensures `isComplete` always exists and is set to True for backward compatibility.
     NOTE:: Expected out series serialization
     {
         "description": {
@@ -293,6 +298,9 @@ def serialize_output_series(series: Series) -> dict[any]:
     # Remove the automatically serialized dataFrame
     del serialized['_Series__dataFrame']
 
+    # Always include isComplete for backward compatibility
+    serialized['isComplete'] = True
+
     # Serialize the dataFrame by our own rules
     serialized_data = []
     for _, row in series.dataFrame.iterrows():
@@ -302,5 +310,11 @@ def serialize_output_series(series: Series) -> dict[any]:
             "timeGenerated":  jsonable_encoder(row['timeGenerated']),
             "leadTime":       jsonable_encoder(row['leadTime'])
         })
+
+        # Replace NaNs with None and ensure JSON safe types
+        row_dict = {k: None if pd.isna(v) else v for k, v in row_dict.items()}
+        encoded_row = {k: jsonable_encoder(v) for k, v in row_dict.items()}
+        serialized_data.append(encoded_row)
+
     serialized['_Series__data'] = serialized_data # Add it back to the response
     return serialized

--- a/src/tests/UnitTests/test_unit_SeriesProvider.py
+++ b/src/tests/UnitTests/test_unit_SeriesProvider.py
@@ -101,7 +101,7 @@ df_correct_three_hour_series_middle_changed.loc[0] = ['1', 'test', datetime(2000
 df_correct_three_hour_series_middle_changed.loc[1] = ['2', 'test', datetime(2000, 1, 1, hour=2), datetime(2000, 1, 1, hour=0), None, None]
 df_correct_three_hour_series_middle_changed.loc[2] = ['1', 'test', datetime(2000, 1, 1, hour=3), datetime(2000, 1, 1, hour=0), None, None]
 
-@pytest.mark.parametrize("seriesDescription, timeDescription, df_DB, df_DI, correctness", [
+@pytest.mark.parametrize("seriesDescription, timeDescription, df_DB, df_DI", [
     (test_series_desc, three_hour_time_desc, df_correct_three_hour_series.copy(deep=True), None), # Fully correct Series from DB, no DI series, 
     (test_series_desc, three_hour_time_desc, get_input_dataFrame(), df_correct_three_hour_series.copy(deep=True)), # Fully correct Series from DI, empty DB, 
     (test_series_desc, three_hour_time_desc, df_correct_three_hour_series_missing_one.copy(deep=True), None), # Missing one from DB, no DI series


### PR DESCRIPTION
# About
To close #717 
Even though Series.isComplete no longer exists, every API response will still include "isComplete": true in its JSON output so that downstream services expecting isComplete will continue to work unchanged. The change is limited to serialization only, which means our ingestion, processing, and API endpoints stay untouched.

# To Test
I'll be for real guys!! Not really a way to test this because it depends so much on the other refactors (that I... have not reviewed yet). This is something that we'll have to check as we merge things I think. But in theory (I think) this should ensure that isComplete is marked as true so that downstream things that use semaphore data (Flare) don't have to worry about the fact that the isComplete is no longer a part of the series object. 