### PR TITLE
Updating transform modle to run at 31 minuets past the hour

### DIFF
--- a/data/dspec/Magnolia/12/magnolia_transform_12.json
+++ b/data/dspec/Magnolia/12/magnolia_transform_12.json
@@ -6,7 +6,7 @@
     "modelFileName": "./Magnolia/12hr_leadtime_2ndANN",
     "timingInfo":{
         "active": true,
-        "offset": 1320,
+        "offset": 1860,
         "interval": 3600
     },
     "outputInfo": {

--- a/data/dspec/Magnolia/24/magnolia_transform_24.json
+++ b/data/dspec/Magnolia/24/magnolia_transform_24.json
@@ -6,7 +6,7 @@
     "modelFileName": "./Magnolia/24hr_leadtime_2ndANN",
     "timingInfo":{
         "active": true,
-        "offset": 1320,
+        "offset": 1860,
         "interval": 3600
     },
     "outputInfo": {

--- a/data/dspec/Magnolia/48/magnolia_transform_48.json
+++ b/data/dspec/Magnolia/48/magnolia_transform_48.json
@@ -6,7 +6,7 @@
     "modelFileName": "./Magnolia/48hr_leadtime_48HrsOfWind_2ndANN",
     "timingInfo":{
         "active": true,
-        "offset": 1320,
+        "offset": 1860,
         "interval": 3600
     },
     "outputInfo": {


### PR DESCRIPTION
# What?
We are altering the schedule for the magnolia models to run at 31 minuets past the hour so the premodels have a chance to finish before we try and run them.

# To test
You can try running the models but nothing really was changed.
