### PR TITLE
Fixing bug in text and refixing NOAATANDC

### DIFF
--- a/src/DataIngestion/DI_Classes/NOAATANDC.py
+++ b/src/DataIngestion/DI_Classes/NOAATANDC.py
@@ -167,8 +167,8 @@ class NOAATANDC(IDataIngestion):
             log(f'NOAA COOPS invalid request error: {e}')
             return None
 
-        if isSinglePoint:
-            data = data.loc[[fromTime.replace(tzinfo=timezone.utc)]]
+        if isSinglePoint: # Select only the single point we want
+            data = data.loc[[fromTime.replace(tzinfo=None)]]
 
         return data, lat_lon
 

--- a/src/tests/UnitTests/test_NOAATANDC.py
+++ b/src/tests/UnitTests/test_NOAATANDC.py
@@ -27,8 +27,8 @@ class TestNOAATANDCUnit:
     def setup_method(self):
         """Setup for each test method."""
         self.noaa_ingester = NOAATANDC()
-        self.from_date = datetime.combine(date(2024, 12, 28), time(10, 0), tzinfo=timezone.utc)
-        self.to_date = datetime.combine(date(2024, 12, 28), time(20, 0), tzinfo=timezone.utc)
+        self.from_date = datetime.combine(date(2024, 12, 28), time(10, 0))
+        self.to_date = datetime.combine(date(2024, 12, 28), time(20, 0))
         self.sample_lat_lon = (29.3108, -94.7933)  # Sample coordinates
         
         # Create sample NOAA API response DataFrame
@@ -101,7 +101,7 @@ class TestNOAATANDCUnit:
     def test_fetch_NOAA_data_single_point(self, mock_station_class):
         """Test NOAA API data fetch for single point in time."""
         # Setup for single point request
-        single_time = datetime.combine(date(2024, 12, 28), time(12, 0), tzinfo=timezone.utc)
+        single_time = datetime.combine(date(2024, 12, 28), time(12, 0))
         single_data = pd.DataFrame({'v': [1.5]}, index=[single_time])
         
         mock_station = Mock()


### PR DESCRIPTION
So what was happening here is that NOAA gives back timezone unaware datetimes. In the test code however, very cool-y the NOAA code is mocked out. Unfortunately the mocked version uses timezone AWARE datetimes. So the fix here is to change the code in NOAATANDC to expect time zone unaware datetimes and change the tests to use timezone unaware datetimes. We do convert to time zone aware later down the line before ingesting in semaphore.

To test run:
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json`
and the tests:
`docker exec semaphore-core python3 -m pytest`