### PR TITLE
Fixing series provider to handle the special case of SMEAPHORE ingestion

### DIFF
--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -55,7 +55,7 @@ class SeriesProvider():
         reference_time = datetime.now(timezone.utc)
 
         # If the data source is from the semaphore ingestion class, we ignore the default behavior and always request new data.
-        if seriesDescription.dataSource == 'SEMAPHORE':
+        if seriesDescription.dataSource.upper() == 'SEMAPHORE':
             return self.__data_ingestion_query(seriesDescription, timeDescription)
         
         # We request new data if:


### PR DESCRIPTION
# What:
The transform magnolia models (stage 2) are complaining about missing all of the data from the magnolia models (stage 1). This pointed me to series provider as likely something was going wrong with requesting it, especially as the stage one data does exist on time. This was true as the SEMAPHORE ingestion class has a special case that prevents it from being inserted in the DB (because its already in the db output table so putting it in the input tables would duplicate it) However, the new series provider never directly returns data ingestion results like the old series provider did. So the Semaphore data would get ingested and then thrown away and the database would be queried but ofc the data isnt there.

# Fixed
To fix this I updated the ingest data method in series provider to return its results and then made a special case if the source is semaphore.

# To test
You can back run all the stage one models and then run the stage 2 model. But realistically I would just look at the code and approve it if you feel its correct. 