### PR TITLE
Serializing datetimes as datetime unaware

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -245,8 +245,8 @@ def serialize_input_series(series: Series) -> dict[any]:
         row_dict = {
             "dataValue":        row['dataValue'],
             "dataUnit":         row['dataUnit'],
-            "timeVerified":     row['timeVerified'],
-            "timeGenerated":    row['timeGenerated'],
+            "timeVerified":     row['timeVerified'].replace(tzinfo=None),
+            "timeGenerated":    row['timeGenerated'].replace(tzinfo=None),
             "longitude":        row['longitude'],
             "latitude":         row['latitude']
         }
@@ -305,7 +305,7 @@ def serialize_output_series(series: Series) -> dict[any]:
         serialized_data.append({
             "dataValue":      jsonable_encoder(row['dataValue']),
             "dataUnit":       jsonable_encoder(row['dataUnit']),
-            "timeGenerated":  jsonable_encoder(row['timeGenerated']),
+            "timeGenerated":  jsonable_encoder(row['timeGenerated'].replace(tzinfo=None)),
             "leadTime":       jsonable_encoder(row['leadTime'])
         })
 


### PR DESCRIPTION
# Why?

Flare is crashing, failing to parse time zone aware date times as time zone unaware date times.

# Fix:
I updated the serializer to convert the timezone aware datetimes to timezone unaware datetimes. The way I see it is there are two solutions:
1. Update flare to timezone aware datetimes
2. Update the serializer to properly keep the datetimes as they were.
I went with the second option due to my understanding of best practices. The API needs to stay static for downstream endpoints which means keeping time zone unaware date times in our response.

To test:
1. `git fetch origin`
2. On flare, pull this specific branch to ensure no other errors will block this test: `git checkout 748-fixing-500-error-when-requesting-ndfd_exp-data-from-flare`
3. Edit your flare .env file to point at your local api: `SEMAPHORE_API_URL = "http://host.docker.internal:8888/"`
4. Build BOTH flare and semaphore: `docker compose up --build -d`
5. In flare run: `docker exec flare-backend python3 /app/backend/flareRunner.py -v  -c /app/data/cspec/TWC-NDFD-Laguna-Madre_Air-Temperature-Predictions_240hrs.json`
6.  You should see NO errors if all is right and see data successfully pulled from semaphore.