### PR TITLE
Fixing dict error and no data error

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -185,6 +185,9 @@ def serialize_series(series: Series) -> dict[any]:
     anything downstream
     """
 
+    if series is None:
+        return dict()
+
     if isinstance(series.description, SemaphoreSeriesDescription):
         return serialize_output_series(series)
 
@@ -310,7 +313,13 @@ def serialize_output_series(series: Series) -> dict[any]:
         })
 
         # Replace NaNs with None and ensure JSON safe types
-        row_dict = {k: None if pd.isna(v) else v for k, v in row_dict.items()}
+        row_dict = {}
+        for k, v in row.items():
+            if type(v) == list:
+                    row_dict[k] = None if pd.isna(v).any() else v
+            else:
+                row_dict[k] = None if pd.isna(v) else v
+
         encoded_row = {k: jsonable_encoder(v) for k, v in row_dict.items()}
         serialized_data.append(encoded_row)
 


### PR DESCRIPTION
# Why? 
The api is crashing at the latest output endpoint.
<img width="1103" height="985" alt="image" src="https://github.com/user-attachments/assets/82707245-077a-49d2-a0af-772e61b3d040" />

# Fix
The sterilizer for outputs had a undefined variable error and was not compatible with ensemble data. In addition we have had an error for awhile that if there just wasnt data for a request it would crash. I have fixed that too.

# Test
1. Build `docker compose up --build -d`
2. Go to `localhost:8888/docs`
3. Use an output endpoint (latest is recommended) and pull data for a model you have. I used: `MRE_Bird-Island_Water-Temperature_66hr
docker `