### PR TITLE
754 fixing defunct processes on prod and dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./data:/app/data
     healthcheck:
-      test: ["CMD", "curl -f host.docker.internal:8888/health"]
+      test: ["CMD", "curl", "-f", "host.docker.internal:8888/health"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
# Why?
TLDR: The way the semaphore-api health check was written, if the API was overloaded it would leave zombie curl processes. This would needed to be fixed and the changes in this pr does that.

Story time! I worked with Son to figure this out. Basically on both sherlock-prod and sherlock-dev the smeaphore.svc account has HUNDREDS of processes. These process were mostly zombie processes that are marked defunct.
<img width="881" height="734" alt="image" src="https://github.com/user-attachments/assets/c425981a-9e1f-4c99-99fb-dcc372614032" />
Defunct is a tag placed on a process afaik, when they are using wait system calls. Basically if a child process is waiting for its parent process to collect its std out and kill it but the parent never shows up the os will mark it defunct, which means zombie. 

The the question became what are the processes and why are there so many of them? Tracking down its parent process we can see that its the uvicorn process. This is the main process of the semaphore-api container. Now I dint know if the python requests library uses curl under the hood but I do know that the health check in semaphore-api does and its run a lot. With this as hints I went looking.

[This stack overflow ](https://stackoverflow.com/questions/77105400/docker-compose-hundreds-of-health-check-processes-not-terminated) entry caught our eye and it answered the question. Basically we were running our healthcheck with CMD-SHELL. What this means is a child process is spawned to run the shell and then a subprocess is spawned by that to run the curl command. Docker is smart it sees that the process has reached the 5 second timeout and the parent process (uvicorn) hasn't killed it. So it kills it for it, however, docker doesn't know about the curl subprocess that is now headless. (The OS doesn't clean it because the subprocess ppid is still uvcorn, not the intermediate shell process for some reason.) Now this only matters and would happen if the API is too overloaded to go look at the healthcheck... ... ... our api is almost always overloaded meaning many many hundreds of stranded curl processes. 

# The fix
I changed the healthcheck to use CMD instead of CMD shell, there is no shell and only one child process if I understand correctly. This means if our API is being slow, docker will still kill it after the 5 second time out and this should resolve the issue.

# To test
1. Buld: `docker compose up --build -d`
2. See that the api is marked healthy `docker ps`
3. Read the api logs to see the healthcheck results `docker logs semaphote-api --tail 1000`
