### PR TITLE
Fixing the nonetype exception

### DIFF
--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -508,7 +508,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         
         tupleishResult = self.__dbSelection(query_stmt).fetchall()
         
-        if not tupleishResult: #Data is not present in the DB
+        if not tupleishResult or not tupleishResult[0][0]: #Data is not present in the DB
             return False
         
         oldestGeneratedTime = pd.to_datetime(tupleishResult[0][0]).tz_localize(timezone.utc)


### PR DESCRIPTION
The query in db_has_freshly_acquired_data will always return a valid row. Thus not var is not a good enough check to see if there was no valid data in the DB. I updated the check to peek to fix this.

# To test
1) build and run
curl 'http://localhost:8888/semaphore-api/input/source=NOAATANDC/series=dWnDir/location=NorthJetty/fromDateTime=2025112104/toDateTime=2025112106'
You might get a 500 if coors errors out because the data isnt there for the time you want. But as long as you dont seen the nontype exception then its good
