### PR TITLE
Lessened healthchecks for the api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - ./data:/app/data
     healthcheck:
       test: ["CMD", "curl", "-f", "host.docker.internal:8888/health"]
-      interval: 5s
+      interval: 60s
       timeout: 5s
       retries: 5
     extra_hosts:


### PR DESCRIPTION
This ticket is meant to solve why we are getting so many 502's and 504 errors. Most of this ticket was analysis through graphs and sherlock dev.