### PR TITLE
Made MLP-OP inactive

### DIFF
--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -5,7 +5,7 @@
     "author": "Christian Duff",
     "modelFileName": "./MLP-OP",
     "timingInfo":{
-        "active": true,
+        "active": false,
         "offset": 600,
         "interval": 10800
 


### PR DESCRIPTION
## Objective
Make MLP-OP inactive


## How I tested:
I used print statements to see the crontab generated by init_cron.py
Before my changes:
<img width="500" height="249" alt="Screenshot 2025-12-04 155513" src="https://github.com/user-attachments/assets/e16bbd0f-f5b8-46db-9346-e712fb30b012" />

After my changes:
<img width="540" height="268" alt="Screenshot 2025-12-04 155722" src="https://github.com/user-attachments/assets/c74c7a5d-2bbf-40db-be0d-550abe54f1e5" />

## How should you test?
- Build containers: docker compose up --build -d
- Run the code that builds the crontab and see that MLP-OP is set to false:  python3 tools/init_cron.py -r ./data/dspec -i ./schedule
