### PR TITLE
Reference time is being set to now in series provider

### DIFF
--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -139,7 +139,7 @@ class SeriesProvider():
         """
         
         oldest_generated_time = self.seriesStorage.fetch_oldest_generated_time(seriesDescription, timeDescription)
-        
+
         stalenessOffset = timeDescription.stalenessOffset
         if stalenessOffset is None:
             stalenessOffset = timedelta(hours=7) #7 because this accounts for at least 2 data updates for all sources
@@ -152,6 +152,10 @@ class SeriesProvider():
         
         # How far back is the earliest verified time?
         lookback = referenceTime - min_v   # e.g. 24h if min_v = now - 24h
+
+        if lookback < stalenessOffset:
+            lookback = timedelta(0) #Set to 0 so that predictions aren't penalized
+
         
         max_allowed_age = lookback + stalenessOffset
 

--- a/src/tests/UnitTests/data/determine_staleness_inputs_table.csv
+++ b/src/tests/UnitTests/data/determine_staleness_inputs_table.csv
@@ -1,6 +1,6 @@
 generatedTime,verifiedTime,acquiredTime,dataValue,isActual,dataUnit,dataSource,dataLocation,dataSeries,dataDatum,latitude,longitude,ensembleMemberID
-2025-09-12 00:00,2025-09-12 00:00,2025-09-12 03:00,12,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
-2025-09-12 01:00,2025-09-12 00:00,2025-09-12 03:45,11,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
+2025-09-12 00:10,2025-09-12 00:00,2025-09-12 03:00,12,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
+2025-09-12 00:30,2025-09-12 00:00,2025-09-12 03:45,11,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
 2025-09-12 02:00,2025-09-12 01:00,2025-09-12 03:05,21,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
 2025-09-12 03:00,2025-09-12 01:00,2025-09-12 03:36,21,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,
 2025-09-12 04:00,2025-09-12 02:00,2025-09-12 03:55,20,false,m,NOAATANDC,NorthJetty,dWl,NAVD,27.8,-97.4,

--- a/src/tests/UnitTests/test_unit_sqlAlchemy.py
+++ b/src/tests/UnitTests/test_unit_sqlAlchemy.py
@@ -124,18 +124,18 @@ def seed_inputs_once(engine, inputs_table):
     "series_kwargs, from_str, to_str, expected_result",
     [
         (
-        #Tests missing rows
+        #Tests missing rows & 0 clamping
             dict(dataSource="NOAATANDC", dataSeries="dWl",
                  dataLocation="NorthJetty", dataDatum="NAVD"),
-            "2025091200", "2025091223",
-        True #Returned date: 2025-09-12 01:00
+            "2025091202", "2025091223",
+        True #Returned date: 2025-09-12 05:00
         ),
         #Tests multiple verified times for one generated time
         (
             dict(dataSource="NDFD_EXP", dataSeries="pWnSpd",
                  dataLocation="Aransas", dataDatum="NA"),
-            "2025091200", "2025091223",
-            False #Returned date: 2025-09-12 00:05
+            "2025091201", "2025091223",
+            False #Returned date: 2025-09-11 00:05
         ),
         (
             dict(dataSource="TWC", dataSeries="pAirTemp",
@@ -168,7 +168,7 @@ def test_determine_staleness_with_mock_db(engine, inputs_table, series_kwargs, f
     time_desc = TimeDescription(fromDateTime=from_dt, toDateTime=to_dt)
     time_desc.interval = timedelta(hours=1)
     reference_time = datetime.combine(date(2025, 9, 12), time(2, 0), tzinfo=timezone.utc)
-    time_desc.stalenessOffset = timedelta(hours=1)
+    time_desc.stalenessOffset = timedelta(hours=3)
 
     seriesProvider = SeriesProvider()
     actual_result = seriesProvider.db_has_freshly_acquired_data(series_desc, time_desc, reference_time)


### PR DESCRIPTION
## The problem
In series provider reference time is being set to now.  This works for real-time predictions and measurements, but fails for historical data requests.

## How I decided to solve it
I kept reference time as now, since comparing to now is the best way to know how long the data has been in the database. However, instead of treating all requests the same, we adjust the freshness window based on how far back the request is looking. I believe this is the best route as it limits the further manipulation of other files, while effectively ensuring the freshness of data in the past, present, and future. 

For real-time predictions/measurements:

- fromTime ≈ now → lookback = 0

- max_allowed_age = stalenessOffset (same behavior as before)

For historical requests:

- fromTime is farther in the past → lookback expands the freshness window

- This prevents valid historical data from being marked stale

For future predictions:

- fromTime ≥ now → lookback = 0

- Freshness behaves like the original logic

## Potential Questions
- Why are you using the verified from time? Because fromTime represents the earliest verified time the caller needs.
By anchoring staleness grace to fromTime, we ensure enough freshness window for the historical range requested. 


## How to test
- `docker compose up --build -d`
- `docker exec semaphore-core python -m pytest -s`
- docker exec semaphore-core python3 src/semaphoreRunner.py -d data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json