### PR TITLE
fixed a bug with output endpoints returning duplicate series data

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -330,13 +330,6 @@ def serialize_output_series(series: Series) -> dict[any]:
     # Serialize the dataFrame by our own rules
     serialized_data = []
     for _, row in series.dataFrame.iterrows():
-        serialized_data.append({
-            "dataValue":      jsonable_encoder(row['dataValue']),
-            "dataUnit":       jsonable_encoder(row['dataUnit']),
-            "timeGenerated":  jsonable_encoder(row['timeGenerated'].replace(tzinfo=None)),
-            "leadTime":       jsonable_encoder(row['leadTime'])
-        })
-
         # Replace NaNs with None and ensure JSON safe types
         row_dict = {}
         for k, v in row.items():
@@ -345,8 +338,12 @@ def serialize_output_series(series: Series) -> dict[any]:
             else:
                 row_dict[k] = None if pd.isna(v) else v
 
-        encoded_row = {k: jsonable_encoder(v) for k, v in row_dict.items()}
-        serialized_data.append(encoded_row)
+        serialized_data.append({
+            "dataValue":      jsonable_encoder(row_dict['dataValue']),
+            "dataUnit":       jsonable_encoder(row_dict['dataUnit']),
+            "timeGenerated":  jsonable_encoder(row_dict['timeGenerated'].replace(tzinfo=None)),
+            "leadTime":       jsonable_encoder(row_dict['leadTime'])
+        })
 
     serialized['_Series__data'] = serialized_data # Add it back to the response
     return serialized


### PR DESCRIPTION
### Issue
ouput endpoints on the api append 2 copies of the same data, one without TZ info and one with it.

### Solution
I moved the inner for loop to the top of the outer for loop to keep the json safe types then just changed append variable to the result of the inner for loop

### To test
1. `docker compose up --build -d`
2. `docker exec semaphore-core python3 -m pytest`
3. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Inundation/June/ar_inundation_jun_24h.json`
4. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json`

ensure models and pytests pass, then
5. go to http://localhost:8888/semaphore-api/docs#/
6. Run any of the output queries, I ran ar_inundation_jun_24h with output latest.

Ensure the series data block only has 1 element and that the generated time does NOT have tz info

### Expected output 
<img width="788" height="608" alt="image" src="https://github.com/user-attachments/assets/6a25b041-17d8-498c-b079-db0e73c013df" />
