### PR TITLE
Remove old logic from fetch_oldest_generated_time

### DIFF
--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -14,7 +14,7 @@ determines the expected date range via the timeDescription and checks for missin
 #Imports
 from DataClasses import Series
 from DataValidation.IDataValidation import IDataValidation
-from utility import log
+from utility import log_error
 from datetime import timedelta, datetime
 from pandas import date_range
 
@@ -31,7 +31,7 @@ class DateRangeValidation(IDataValidation):
         """
 
         if series.dataFrame is None or len(series.dataFrame) <= 0:
-            log('DateRangeValidation: No data in series to validate.')
+            log_error('DateRangeValidation: No data in series to validate.')
             return False # No data to validate
     
         df_to_validate = series.dataFrame.copy()
@@ -48,9 +48,9 @@ class DateRangeValidation(IDataValidation):
         missing_value_count = df_to_validate['dataValue'].isnull().sum()
         
         if missing_value_count > 0:
-            log(f'DateRangeValidation: Series {series} is missing {missing_value_count} values.')
+            log_error(f'DateRangeValidation: Series {series} is missing {missing_value_count} values.')
             for missing_time in df_to_validate[df_to_validate['dataValue'].isnull()].index:
-                log(f'\tMissing time: {missing_time}')
+                log_error(f'\tMissing time: {missing_time}')
             return False
         
         # only unit tests will skip this check unless they set a reference time
@@ -62,8 +62,8 @@ class DateRangeValidation(IDataValidation):
 
             # validate that the data isn't stale 
             if time_difference > series.timeDescription.stalenessOffset:
-                log(f'DateRangeValidation: Series {series} is stale.\n')
-                log(f'Time difference: {time_difference}. Staleness offset: {series.timeDescription.stalenessOffset}\n')
+                log_error(f'DateRangeValidation: Series {series} is stale.\n')
+                log_error(f'Time difference: {time_difference}. Staleness offset: {series.timeDescription.stalenessOffset}\n')
                 return False
         
         return True

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -481,8 +481,6 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
         if not tupleishResult or not tupleishResult[0][0]: 
             return None
         
-        print(f'Tuplish Result: {tupleishResult}')
-        
         oldestGeneratedTime = pd.to_datetime(tupleishResult[0][0]).tz_localize(timezone.utc)
 
         return oldestGeneratedTime


### PR DESCRIPTION
# What was changed
* The old logic that returned a bool for staleness is removed and the data types returned are correctly fixed to return either None or DateTime
* updated the logging statements in date range validation to use log_error instead of log(). This was causing staleness errors to not be printed when using log( ) and since every validation check that returns false here will cause a semaphore data exception, I changed them to log_error()

# To test
`docker compose up --build -d`
`docker exec semaphore-core python3 -m pytest` See notes below about this
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json`
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Inundation/June/ar_inundation_jun_24h.json`
`docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ThermalRefuge.json`

# Notes
* I tested using the 3 models listed above and running the pytests
* These 7 tests will fail and that is expected. The reason is because of our new query statements using DISTINCT ON is unique to Postgresql and these 7 tests use sqlite to create an in memory db. This fails because sqlite doesn't recognize the "ON" clause causing them to fail.
<img width="1734" height="362" alt="image" src="https://github.com/user-attachments/assets/23c4664e-48f0-458c-b64f-f5d56a04f8ab" />
