### PR TITLE
Refrence time not providing an accurate messure of passed time for the __check_verified_time_for_ingestion function

### DIFF
--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -204,11 +204,11 @@ class SeriesProvider():
         True (should ingest) if:
         - No rows exists for the provided series and time description
         - The max verified time < requested toDateTime (more data might be available)
-            AND the time since acquisition (now - acquired_time) is strictly greater than the threshold (> threshold)
+            AND the time since acquisition (now - acquired_time) is greater than or equal to the threshold (>= threshold)
     
         Returns False (should NOT ingest) if:
         - The max verified time >= requested toDateTime
-            OR the time since acquisition (now - acquired_time) is less than or equal to the threshold (<= threshold)
+            OR the time since acquisition (now - acquired_time) is less than the threshold (< threshold)
 
         NOTE::
         The now time and toDateTime are both converted to tz naive for comparison.


### PR DESCRIPTION
## Issue Description
Models are failing with DateRangeValidation Failed errors, consistently missing the last data point in their requested time range. The root cause is in SeriesProvider.__check_verified_time_for_ingestion(), which uses the rounded reference_time instead of the current time when calculating time elapsed since last data acquisition.

How the Bug Occurs:
- Reference Time is Rounded: When a model runs at 16:31, the reference_time is rounded to the nearest hour (16:00) for prediction purposes
- Acquired Time is Actual: Data ingestion stores the actual wall-clock time when data was acquired (16:31)
- Faulty Difference Calculation: When the next model runs at 17:31:
  - reference_time = 17:00 (rounded)
  - acquired_time = 16:31 (actual from previous run)
  - difference = 17:00 - 16:31 = 28 minutes
  - threshold = 1 hour
  - Check: 28 minutes > 1 hour = FALSE ❌
- No Ingestion Triggered: The system doesn't ingest new data because it thinks only 28 minutes have passed, when in reality 60 minutes have passed.

## Solution
Replace the rounded reference_time with actual current time (datetime.now(timezone.utc)) when calculating elapsed time since last acquisition. This was the first solution I thought of but there might be a better way to do it, so please let me know what you think about the fix!

## Testing
This is how I figured out the error, since I was trying to recreate the dev environment locally so I could have a million print statements.
Run a model: `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json -v `
Then run it again an hour later and make sure it re-ingests data: `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json -v`



