### PR TITLE
Ensured daterange validation worked with future generated times

### DIFF
--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -52,13 +52,12 @@ class DateRangeValidation(IDataValidation):
             for missing_time in df_to_validate[df_to_validate['dataValue'].isnull()].index:
                 log_error(f'\tMissing time: {missing_time}')
             return False
-        
         # only unit tests will skip this check unless they set a reference time
         # and measurements that do not have stalenessOffset set will skip this check
         if self.referenceTime is not None and series.timeDescription.stalenessOffset is not None:
             
             # calculate time difference between reference time and earliest generated time
-            time_difference = self.referenceTime - df_to_validate['timeGenerated'].min()
+            time_difference = abs(self.referenceTime - df_to_validate['timeGenerated'].min())
 
             # validate that the data isn't stale 
             if time_difference > series.timeDescription.stalenessOffset:


### PR DESCRIPTION
## Objective:
The current code uses referenceTIme - generatedTIme. We then compare the result against the StalenessOffset. When the generated time is later than reference time then it results in a negative time. A negative time will always be less than the StalenessOffset making it always true. 

Generated time tends to be in the future when dealing with sources that set their generated time as the same time as verified time.
<img width="315" height="98" alt="Screenshot 2025-12-20 214233" src="https://github.com/user-attachments/assets/558345af-b01b-4d1b-8ff0-ea49778ca1ae" />



## Changes:
- Made the result of (referenceTime - generatedTime) absolute.
-  Added test cases to the Date range Validation test ensuring the freshness check works for future generated times.

## How to Test:
- docker compose up --build -d
- docker exec semaphore-core python -m pytest