### PR TITLE
increasing staleness offset due to NDFD

### DIFF
--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_108",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_114",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_120",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_126",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_18",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_24",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_30",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_36",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_42",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_9",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_48",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_54",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_60",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_66",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_72",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_12",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_78",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_84",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_90",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_96",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
@@ -71,6 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_102",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -46,7 +46,8 @@
             "unit": "celsius",
             "interval": 10800,
             "range": [16, 1],
-            "outKey": "SBI_PAT_16"
+            "outKey": "SBI_PAT_16",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [],

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -91,6 +91,7 @@
             "interval": 3600,
             "range": [7, 1],
             "outKey": "PL_PWNDIR_F7",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -109,6 +110,7 @@
             "interval": 3600,
             "range": [7, 1],
             "outKey": "PL_PWSPD_F7",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/12/magnolia_transform_12.json
+++ b/data/dspec/Magnolia/12/magnolia_transform_12.json
@@ -37,6 +37,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "PL_WNDIR_F12",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -55,6 +56,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "PL_WNDSPD_F12",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -91,6 +91,7 @@
             "interval": 3600,
             "range": [19, 1],
             "outKey": "PL_PWNDIR_F20",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -109,6 +110,7 @@
             "interval": 3600,
             "range": [19, 1],
             "outKey": "PL_PWSPD_F20",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/24/magnolia_transform_24.json
+++ b/data/dspec/Magnolia/24/magnolia_transform_24.json
@@ -37,6 +37,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "PL_WNDIR_F24",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -55,6 +56,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "PL_WNDSPD_F24",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -91,6 +91,7 @@
             "interval": 3600,
             "range": [43, 1],
             "outKey": "PL_PWNDIR_F43",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -109,6 +110,7 @@
             "interval": 3600,
             "range": [43, 1],
             "outKey": "PL_PWSPD_F43",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/48/magnolia_transform_48.json
+++ b/data/dspec/Magnolia/48/magnolia_transform_48.json
@@ -37,6 +37,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "PL_WNDIR_F48",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -55,6 +56,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "PL_WNDSPD_F48",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WSPD_FUTR_12"
+            "outKey": "WSPD_FUTR_12",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WDIR_FUTR_12"
+            "outKey": "WDIR_FUTR_12",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WSPD_FUTR_24"
+            "outKey": "WSPD_FUTR_24",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WDIR_FUTR_24"
+            "outKey": "WDIR_FUTR_24",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_48"
+            "outKey": "WSPD_FUTR_48",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_48"
+            "outKey": "WDIR_FUTR_48",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_72"
+            "outKey": "WSPD_FUTR_72",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_72"
+            "outKey": "WDIR_FUTR_72",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WSPD_FUTR_12"
+            "outKey": "WSPD_FUTR_12",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WDIR_FUTR_12"
+            "outKey": "WDIR_FUTR_12",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WSPD_FUTR_24"
+            "outKey": "WSPD_FUTR_24",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WDIR_FUTR_24"
+            "outKey": "WDIR_FUTR_24",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_48"
+            "outKey": "WSPD_FUTR_48",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_48"
+            "outKey": "WDIR_FUTR_48",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_72"
+            "outKey": "WSPD_FUTR_72",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_72"
+            "outKey": "WDIR_FUTR_72",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WSPD_FUTR_12"
+            "outKey": "WSPD_FUTR_12",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WDIR_FUTR_12"
+            "outKey": "WDIR_FUTR_12",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WSPD_FUTR_24"
+            "outKey": "WSPD_FUTR_24",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WDIR_FUTR_24"
+            "outKey": "WDIR_FUTR_24",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_48"
+            "outKey": "WSPD_FUTR_48",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_48"
+            "outKey": "WDIR_FUTR_48",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_72"
+            "outKey": "WSPD_FUTR_72",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_72"
+            "outKey": "WDIR_FUTR_72",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WSPD_FUTR_12"
+            "outKey": "WSPD_FUTR_12",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [12, 1],
-            "outKey": "WDIR_FUTR_12"
+            "outKey": "WDIR_FUTR_12",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
@@ -110,7 +110,8 @@
             "unit": "mps",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WSPD_FUTR_24"
+            "outKey": "WSPD_FUTR_24",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -120,7 +121,8 @@
             "unit": "degrees",
             "interval": 3600,
             "range": [24, 1],
-            "outKey": "WDIR_FUTR_24"
+            "outKey": "WDIR_FUTR_24",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_48"
+            "outKey": "WSPD_FUTR_48",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_48"
+            "outKey": "WDIR_FUTR_48",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
@@ -118,7 +118,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WSPD_FUTR_72"
+            "outKey": "WSPD_FUTR_72",
+            "stalenessOffset": 36000
         },
         {
             "_name": "wind direction future",
@@ -136,7 +137,8 @@
                     "limit_area":"inside"    
                 }
             },
-            "outKey": "WDIR_FUTR_72"
+            "outKey": "WDIR_FUTR_72",
+            "stalenessOffset": 36000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/VirginiaKey/12hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/12hr_VirginiaKey_wl_Estrada.json
@@ -58,6 +58,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "VK_PWSPD_F12",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -76,6 +77,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "VK_PWDIR_F12",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/24hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/24hr_VirginiaKey_wl_Estrada.json
@@ -59,6 +59,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "VK_PWSPD_F24",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -77,6 +78,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "VK_PWDIR_F24",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/48hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/48hr_VirginiaKey_wl_Estrada.json
@@ -59,6 +59,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "VK_PWSPD_F48",
+            "stalenessOffset": 36000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -77,6 +78,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "VK_PWDIR_F48",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/72hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/72hr_VirginiaKey_wl_Estrada.json
@@ -59,6 +59,7 @@
             "interval": 3600,
             "range": [72, 1],
             "outKey": "VK_PWSPD_F72",
+            "stalenessOffset": 36000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -77,6 +78,7 @@
             "interval": 3600,
             "range": [72, 1],
             "outKey": "VK_PWDIR_F72",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/96hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/96hr_VirginiaKey_wl_Estrada.json
@@ -59,6 +59,7 @@
             "interval": 3600,
             "range": [96, 1],
             "outKey": "VK_PWSPD_F96",
+            "stalenessOffset": 36000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -77,6 +78,7 @@
             "interval": 3600,
             "range": [96, 1],
             "outKey": "VK_PWDIR_F96",
+            "stalenessOffset": 36000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/src/ModelExecution/dspecParser.py
+++ b/src/ModelExecution/dspecParser.py
@@ -216,19 +216,15 @@ class dspec_sub_Parser_2_0:
                 dSeries.unit = dSeries_dict.get("unit")
                 dSeries.outKey = dSeries_dict.get("outKey")
 
-                # If staleness offset is provided we use it, else we set a default based on range and source:
+                # If staleness offset is provided we use it, else we set a default based on range:
                 # --- If data is in the past there is no staleness offset (None)
-                # --- If data is current/future, set staleness offset based on source:
-                #     - NDFD_JSON: 12 hours (updates irregularly, can have 9+ hour gaps)
-                #     - Other sources: 7 hours
+                # --- If data is current/future we set a default staleness offset of 7 hours
                 fromTimeIsInPast = dSeries.range[1] < 0
-                if fromTimeIsInPast:
-                    default_staleness = None
-                elif dSeries.source == "NDFD_JSON":
-                    default_staleness = timedelta(hours=12)
-                else:
-                    default_staleness = timedelta(hours=7)
-                dSeries.stalenessOffset = dSeries_dict.get("stalenessOffset", default_staleness)
+                stalenessOffsetValue = dSeries_dict.get("stalenessOffset", None if fromTimeIsInPast else timedelta(hours=7))
+                # Convert integer seconds to timedelta if needed
+                if isinstance(stalenessOffsetValue, int):
+                    stalenessOffsetValue = timedelta(seconds=stalenessOffsetValue)
+                dSeries.stalenessOffset = stalenessOffsetValue
 
                 dSeries.verificationOverride = dSeries_dict.get("verificationOverride")
 


### PR DESCRIPTION
**TLDR**
NDFD-JSON updates on irregular intervals that can stretch longer than the default staleness threshold for predictions. So if the source is NDFD-JSON we set the staleness to 12 hours in order to ensure we can run with NDFD-JSON data.  

**The Issue**
In dev models using NDFD-JSON were failing at regular intervals similar to a pattern that can be observed below: 
```
01/14/26 00:20:46: Model Bird-Island_Water-Temperature_102hr completed successfully ✓
01/14/26 01:20:50: Model Bird-Island_Water-Temperature_102hr completed successfully ✓
01/14/26 02:21:04: Time difference: 0 days 07:58:33. Staleness offset: 7:00:00
01/14/26 03:20:57: Time difference: 0 days 08:58:33. Staleness offset: 7:00:00
01/14/26 04:20:58: Model Bird-Island_Water-Temperature_102hr completed successfully ✓
---
01/14/26 12:20:47: Model Bird-Island_Water-Temperature_102hr completed successfully ✓
01/14/26 13:20:45: Time difference: 0 days 07:33:31. Staleness offset: 7:00:00
01/14/26 14:20:46: Time difference: 0 days 08:33:31. Staleness offset: 7:00:00
01/14/26 15:20:49: Time difference: 0 days 09:33:31. Staleness offset: 7:00:00
01/14/26 16:20:45: Time difference: 0 days 10:33:31. Staleness offset: 7:00:00
01/14/26 17:20:37: Model Bird-Island_Water-Temperature_102hr completed successfully ✓
```
My conclusion on this variability was that our forecast office is only updating their grids a few times per day and there's a large gap between these updates. This is because for endpoints other than the Grib2 files (like the json endpoint) I think that updates are mainly event-driven, not on a fixed hourly schedule. 

Mrs. Tissot was kind enough to send through some analysis that she did of the json endpoint. Looking through this file I was able to find similar patterns. Most updates happen every 3 hours during normal periods but there are longer gaps (6-9 hours) that occur regularly, particularly overnight (between evening and early morning) and during afternoon transitions which alings with the timestamps above. An example of long gaps in the data Mrs. Tissot gave me: 
```
9.51 hours (Update #4): Between 2025-11-19 21:00 UTC and 2025-11-20 06:00 UTC
9.00 hours (Updates #4, 20, 25): Multiple instances throughout the dataset
```

**Fix**
This isn't a bug in our code - NDFD JSON forecasts genuinely aren't updated as frequently as the GRIB2 files we originally based our 7-hour offset on. The API serves the same forecast data until the National Weather Service regenerates it, which happens on their schedule, not hourly. My recommendation in this PR is that we update the staleness offset for models that use NDFD to 11 hours due to an observed 10.33 hr gap in updates. Dr. Tissot approved 10 hours, so that's what's in this PR right now, we can watch and change if needed.

**Testing**
- Migrate your database: `docker exec semaphore-core python3 tools/migrate_db.py`
- Run tests: ` docker exec semaphore-core python -m pytest -s src/tests`
- Run model: `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json -v`
    - When I was testing Lighthouse was having an outage so I couldn't get a Bird Island model to run all the way through :/
    - ` docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json -v`
    - The surge models also use NDFD and they ran smoothly though.
Please double check that I've caught all of the instances of NDFD_JSON being used if you can!