### PR TITLE
Api log processor

### DIFF
--- a/tools/APILogProcessing/api-log-processor.py
+++ b/tools/APILogProcessing/api-log-processor.py
@@ -16,7 +16,6 @@ Arguments:
 - logfile (str): Path to the log file to process. Defaults to 'api.log'.
 - --raw_out, -ro (str): Optional. Path to write the raw JSON output of the processed log data. (Better if you want to do further processing)
 - --out, -o (str): Optional. Path to write the generated report. If not provided, the report is printed to stdout.
-import re
 """
 
 LINE_RE = re.compile(


### PR DESCRIPTION
A quick PR. This is the file I used to process the API log files. You can test it by grabbing some logs. I used `docker logs --since <time_value> <container_name_or_id>` and pipped the result to a file. 