### PR TITLE
Fixing ensemble data having its order randomized when its spliced fro…

### DIFF
--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -680,7 +680,7 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
             firstRow = group.iloc[0]
             isEnsemble = firstRow["ensembleMemberID"] is not None
             
-            # If its an ensemble the dataValue is all the values sorted by there ID (to ensure correct order)
+            # If it's an ensemble, the dataValue is all the values sorted by their ID (to ensure correct order)
             # If not an ensemble we just take the solitary dataValue
             if isEnsemble:
                 group = group.sort_values(by=("ensembleMemberID"))


### PR DESCRIPTION
## Why?
An old bit of code was incorrect and would "randomize" the order of ensemble data when it was being spliced. This fixes it to ensure its always ordered properly.

## To test:
1. Run a command like:
```bash 
curl "http://localhost:8888/semaphore-api/output_latest/?modelNames=MRE_Bird-Island_Water-Temperature_120hr" | jq
```
2. Run a query:
```sql
WITH latest_time_per_model AS (
	SELECT 
		o."modelName",
		MAX(o."timeGenerated") AS latest_time
	FROM outputs AS o
	WHERE o."modelName" IN ('MRE_Bird-Island_Water-Temperature_120hr')
	GROUP BY o."modelName"
)
SELECT "dataValue", "ensembleMemberID"
FROM outputs AS o
INNER JOIN latest_time_per_model AS ltpm
	ON o."modelName" = ltpm."modelName"
	AND o."timeGenerated" = ltpm.latest_time
ORDER BY
	o."modelName",
	o."ensembleMemberID";
```
3. Compare the results are in the correct order:
<img width="918" height="580" alt="image" src="https://github.com/user-attachments/assets/c8899959-3378-4539-900b-23dc4b5c819e" />
