### PR TITLE
Adding pg_Stats reset statement and cli

### DIFF
--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -203,7 +203,7 @@ def main():
         except ValueError:
             raise ValueError(f'Invalid version string: {args.version}, aborting!')    
         
-        if target_desc > 255:
+        if len(target_desc) > 255:
             raise ValueError('Description must be 255 characters or less, aborting!')
         
     else:  

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -199,12 +199,12 @@ def main():
     if args.version:
         try:
             target_version = Version.from_dot_separator(args.version)
-            target_desc = args.description if args.description else ''
         except ValueError:
-            raise ValueError(f'Invalid version string: {args.version}, aborting!')    
-        
+            parser.error(f'Invalid version string: {args.version}. Expected format X.X (e.g., 2.1).')
+
+        target_desc = args.description if args.description else ''
         if len(target_desc) > 255:
-            raise ValueError('Description must be 255 characters or less, aborting!')
+            parser.error('Description must be 255 characters or less.')
         
     else:  
         # Read the target version of the database from the static file

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -1,21 +1,31 @@
 # -*- coding: utf-8 -*-
-#init_db.py
 #----------------------------------
 # Created By: Team
 # Created Date: 2/07/2023
 # version 2.0
 #----------------------------------
-"""This file instantiates a db schema over a db connection.
+"""
+Database Migration Tool
+This module provides functionality to manage database schema migrations for the Semaphore project.
+It handles version tracking, migration execution, and rollback operations.
+Command Line Arguments:
+    -v, --version (optional)
+        Target version for migration in format X.X (e.g., 2.1).
+        Used primarily for testing purposes. If not provided, reads from target_version.json.
+    -d, --description (optional)
+        Description for the migration (max 255 characters).
+        Only used when --version flag is specified.
  """ 
 #----------------------------------
 # 
 from os import path
 from os import listdir, getcwd, getenv
 from dotenv import load_dotenv
-from sqlalchemy import create_engine, Engine, inspect, Table, MetaData, select, update
+from sqlalchemy import create_engine, Engine, inspect, Table, MetaData, select, text, update
 from importlib import import_module
 from datetime import datetime, timezone
 from json import load
+import argparse
 
 load_dotenv()
 TARGET_VERSION_FILEPATH = './tools/DatabaseMigration/target_version.json'
@@ -158,11 +168,47 @@ def create_version_lists() -> tuple[list[str], list[tuple[int]]]:
     return names, versions
 
 
+def reset_pg_stats(engine: Engine, current_version: Version) -> None:
+    """ Version 3.5 of the database migration enables pg_stat_statements, which collects query performance statistics. 
+    This function resets the collected statistics after migration to avoid confusion with pre-migration stats.
+
+    NOTE:: This function only fires if the database is being migrated to version 3.5 or higher.
+        :param engine: Engine - The engine to connect to the database with
+        :param current_version: Version - The version of the database before migration
+    """
+    pg_stats_enabled_version = Version.from_dot_separator('3.5')
+    if current_version == pg_stats_enabled_version or current_version > pg_stats_enabled_version:
+        pg_stats_reset_stmt = text('SELECT pg_stat_statements_reset()')
+        with engine.begin() as connection:
+            connection.execute(pg_stats_reset_stmt)
+            connection.commit()
+
+
 def main():
     """The main function of migrate_db.py creates the database engine and passes
        it through the logic to update or rollback the database. 
     """
     print('Beginning Database Migration')
+
+    parser = argparse.ArgumentParser(description='Database migration tool')
+    parser.add_argument('-v', '--version', type=str, required=False, help='Optional target version for the migration, this should only be used for testing purposes. (e.g., 2.1) If not provided, the script will read the target version from the static file.')
+    parser.add_argument('-d', '--description', type=str, required=False, help='Optional description for the migration to be used if the --version flag is used.')
+    args = parser.parse_args()
+
+    # Find the target version to migrate to, either from the command line or from the static file
+    if args.version:
+        try:
+            target_version = Version.from_dot_separator(args.version)
+            target_desc = args.description if args.description else ''
+        except ValueError:
+            raise ValueError(f'Invalid version string: {args.version}, aborting!')    
+        
+        if target_desc > 255:
+            raise ValueError('Description must be 255 characters or less, aborting!')
+        
+    else:  
+        # Read the target version of the database from the static file
+        target_version, target_desc = get_target_version_info() 
 
     # Load database location string
     DB_LOCATION_STRING = getenv('DB_LOCATION_STRING')
@@ -172,9 +218,6 @@ def main():
 
     current_version = get_current_database_version(engine)
     
-    # Read the target version of the database from the static file
-    target_version, target_desc = get_target_version_info()
-
     # Create list of version folders inside of DatabaseMigration folder
     version_names, version_values = create_version_lists()
     
@@ -212,6 +255,9 @@ def main():
 
     # Update last time with description of database
     set_current_database_version(engine, target_version, target_desc)  
+
+    # Reset pg_stat_statements stats if pg_stat_statements was enabled in this migration or a past migration
+    reset_pg_stats(engine, current_version)
 
     # Log that migration has finished
     print(f'Fin!')     

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -51,6 +51,12 @@ class Version():
         if self.major == other.major:
             return self.minor > other.minor
         return self.major > other.major
+    
+    def __ge__(self, other):
+        return self.__gt__(other) or self.__eq__(other)
+    
+    def __le__(self, other):
+        return self.__lt__(other) or self.__eq__(other)
 
     def __eq__(self, other):
         return self.major == other.major and self.minor == other.minor
@@ -168,16 +174,16 @@ def create_version_lists() -> tuple[list[str], list[tuple[int]]]:
     return names, versions
 
 
-def reset_pg_stats(engine: Engine, current_version: Version) -> None:
+def reset_pg_stats(engine: Engine, target_version: Version) -> None:
     """ Version 3.5 of the database migration enables pg_stat_statements, which collects query performance statistics. 
     This function resets the collected statistics after migration to avoid confusion with pre-migration stats.
 
     NOTE:: This function only fires if the database is being migrated to version 3.5 or higher.
         :param engine: Engine - The engine to connect to the database with
-        :param current_version: Version - The version of the database before migration
+        :param target_version: Version - The version of the database after migration
     """
     pg_stats_enabled_version = Version.from_dot_separator('3.5')
-    if current_version == pg_stats_enabled_version or current_version > pg_stats_enabled_version:
+    if target_version >= pg_stats_enabled_version:
         pg_stats_reset_stmt = text('SELECT pg_stat_statements_reset()')
         with engine.begin() as connection:
             connection.execute(pg_stats_reset_stmt)


### PR DESCRIPTION
## What is?
1) This change makes the db_migration script reset the pg_stats each time a migration happens iff the targeted version is greater than or equal the version that adds pg_stats to the db.
2) This adds a cli to the migration script for easier testing of rollbacks and updates. This is a long needed addition. I agree this is out of scope but I was already there and it made it easier to test.

## How test?
1) Build and run `docker compose up --build -d`
2) Open pg_admin. Testing the reset time of pg_stats is easier. You can see the last time the stats were reset by executing:
```sql
SELECT stats_reset FROM pg_stat_statements_info;
```
3) Invoke a bogus migration: `docker exec semaphore-core python3 tools/migrate_db.py --version "3.5"` You will see the reset time update to now. IT might be blank for a few seconds as it only adds the new time when it logs a query has run.

You can also test the CLI, documentation is provided at the top of the script, but
1) `docker exec semaphore-core python3 tools/migrate_db.py --version "3.5"` properly updates to 3.5
2) `docker exec semaphore-core python3 tools/migrate_db.py --version "3.1"` properly rolls back to 3.1
3) `docker exec semaphore-core python3 tools/migrate_db.py` reads from file and properly updates to 3.5
4) `docker exec semaphore-core python3 tools/migrate_db.py --version "AHHHHHHHHHHHH"` properly aborts
5) `docker exec semaphore-core python3 tools/migrate_db.py --version "3.5" --description "AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH"` Properly aborts, desc is longer than 255