### PR TITLE
Revert "Adding flag to skip ingestion logic"

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -100,7 +100,7 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
 
     provider = SeriesProvider()
     
-    responseSeries = provider.request_input(requestDescription, timeDescription, nowTime, skipIngestionLogic= True)
+    responseSeries = provider.request_input(requestDescription, timeDescription, nowTime)
 
     # Protect the API's JSON ENCODER from freaking out about floats sneaking from the ingestion class
     responseSeries.dataFrame['dataValue'] = responseSeries.dataFrame['dataValue'].astype(str)

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -46,34 +46,26 @@ class SeriesProvider():
         return returningSeries
           
     
-    def request_input(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, referenceTime: datetime, skipIngestionLogic: bool = False) -> Series:
+    def request_input(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, referenceTime: datetime) -> Series:
         """This method attempts to return a series matching a series description and a time description.
-
-        NOTE::if the data source in the series description is "SEMAPHORE", we skip all freshness and verified time checks and directly query for new data, 
-            as this is a special case used to ingest outputs as inputs for other models.
-
             :param seriesDescription - A description of the wanted series.
             :param timeDescription - A description of the temporal information of the wanted series. 
-            :param referenceTime - The time of execution 
-            :param skipIngestionLogic - A flag to determine whether to skip the ingestion logic and directly query the database for the requested series. Default is False.
+            :param refrenceTime - The time of execution 
             :returns series - The series containing as much data as could be found.
         """
         log(f'\nInit input request from \t{seriesDescription}\t{timeDescription}')
+
+        # assume we have not ingested data yet
+        already_ingested_data = False
 
         # If the data source is from the semaphore ingestion class, we ignore the default behavior and always request new data.
         if seriesDescription.dataSource.upper() == 'SEMAPHORE':
             return self.__data_ingestion_query(seriesDescription, timeDescription)
         
-        if skipIngestionLogic:
-            log(f'Init DB Query...')
-            return self.seriesStorage.select_input(seriesDescription, timeDescription)
-        
-        # assume we have not ingested data yet
-        already_ingested_data = False
-
         # We request new data if:
         #   - The data in the db is stale.
         #   - We can get more verified times for the requested range.
+
         # always call the db freshness check to ensure we aren't using old data
         db_is_fresh = self.db_has_freshly_acquired_data(seriesDescription, timeDescription, referenceTime)
         if not db_is_fresh:
@@ -86,8 +78,7 @@ class SeriesProvider():
             if should_ingest_for_verified_time:
                 self.__data_ingestion_query(seriesDescription, timeDescription)
 
-        log(f'Init DB Query...')
-        return self.seriesStorage.select_input(seriesDescription, timeDescription)
+        return self.__data_base_query(seriesDescription, timeDescription)
     
 
     def request_output(self, method: str, **kwargs) -> Series | list[Series] | None:
@@ -128,8 +119,6 @@ class SeriesProvider():
                     raise Semaphore_Exception(f'Method {method} in SeriesProvider.request_output received {kwargs} call should be formatted like request_output("SPECIFIC", semaphoreSeriesDescription= DESCRIPTION, timeDescription= DESCRIPTION)')
             case _:
                 raise NotImplementedError(f'Method {method} has not been implemented in SeriesProvider.request_output')
-            
-            
     def db_has_freshly_acquired_data(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, referenceTime: datetime) -> bool:
         """
         Checks whether the database contains fresh data for the requested series. 
@@ -159,6 +148,18 @@ class SeriesProvider():
   
         return is_fresh
     
+
+    def __data_base_query(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) ->Series:
+        """ Handles the process of getting requested data from series storage.
+        :param seriesDescription: SeriesDescription - The semantic description of request
+        :param timeDescription: TimeDescription - The temporal description of the request
+        :returns Series
+            - Validated results: Series - The results from the DB that have gone through validation.
+            - Raw results: Series - The raw results from the database.
+        """
+
+        log(f'Init DB Query...')
+        return  self.seriesStorage.select_input(seriesDescription, timeDescription)
         
     def __data_ingestion_query(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription) -> Series | None:
         """ Handles the process of getting requested data from series storage.

--- a/src/tests/IntegrationTests/test_SeriesProvider.py
+++ b/src/tests/IntegrationTests/test_SeriesProvider.py
@@ -14,7 +14,7 @@
 import sys
 sys.path.append('/app/src')
 from dotenv import load_dotenv
-from unittest.mock import MagicMock
+    
 import pytest
 from datetime import datetime, timedelta, timezone
 from src.SeriesProvider.SeriesProvider import SeriesProvider, TimeDescription, Series, SeriesDescription, SemaphoreSeriesDescription
@@ -36,30 +36,6 @@ def test_request_input(seriesDescription: SeriesDescription, timeDescription: Ti
         seriesProvider.request_input(seriesDescription, timeDescription, datetime(2001, 12, 28, tzinfo=timezone.utc))
     except ModuleNotFoundError: #Catches when the DI factory is called, which is far out of this unit test
         assert True 
-
-
-def test_skip_ingestion_logic(monkeypatch):
-    """This tests that request input can run with no errors when skipIngestionLogic is true.
-    NOTE::This is a unit test and a proper unit tests can not be made with current framework!
-    """
-    load_dotenv()
-    seriesProvider = SeriesProvider()
-
-    mocked_check_verified_time_for_ingestion = MagicMock(return_value=False)
-    mocked_db_has_freshly_acquired_data = MagicMock(return_value=True)
-
-    # Mock the 'method_to_mock' method on the specific instance
-    monkeypatch.setattr(seriesProvider, "_SeriesProvider__check_verified_time_for_ingestion", mocked_check_verified_time_for_ingestion)
-    monkeypatch.setattr(seriesProvider, "db_has_freshly_acquired_data", mocked_db_has_freshly_acquired_data)
-
-    seriesDescription = SeriesDescription('apple', 'pear', 'grape')
-    timeDescription = TimeDescription(datetime(2001, 12, 28, tzinfo=timezone.utc), datetime(2001, 12, 28, tzinfo=timezone.utc) + timedelta(hours=24), timedelta(hours=1))
-    timeDescription.stalenessOffset = None
-    seriesProvider.request_input(seriesDescription, timeDescription, datetime(2001, 12, 28, tzinfo=timezone.utc), True)
-
-    # If the ingestion logic is correctly skipped, the mocked methods should not be called
-    assert not mocked_check_verified_time_for_ingestion.called, "Expected __check_verified_time_for_ingestion to not be called when skipIngestionLogic is True"
-    assert not mocked_db_has_freshly_acquired_data.called, "Expected db_has_freshly_acquired_data to not be called when skipIngestionLogic is True"
 
 
 


### PR DESCRIPTION
Reverts conrad-blucher-institute/semaphore#880


It was decided that this logic should be reverted due to flare relying on ingesting NOAATANDC