### PR TITLE
Add multi member runs to model runner

### DIFF
--- a/src/ModelExecution/dspecParser.py
+++ b/src/ModelExecution/dspecParser.py
@@ -173,7 +173,26 @@ class dspec_sub_Parser_2_0:
         self.__dspec.modelName = self.__dspec_json["modelName"]
         self.__dspec.modelVersion = self.__dspec_json["modelVersion"]
         self.__dspec.author = self.__dspec_json["author"]
-        self.__dspec.modelFileName = self.__dspec_json["modelFileName"]
+
+        has_single = bool(self.__dspec_json.get("modelFileName", "").strip())
+        has_pattern = bool(self.__dspec_json.get("modelFileNamePattern", "").strip())
+
+        # These are needed to load the models
+        if not has_single and not has_pattern:
+            raise ValueError(
+                f"{self.__dspec.modelName}: must define either 'modelFileName' or 'modelFileNamePattern'"
+            )
+        
+        # modelFileName is used for single model dspecs and modelFileNamePattern is used for multi model dspecs.
+        # We can't use both.
+        if has_single and has_pattern:
+            raise ValueError(
+                f"{self.__dspec.modelName}: cannot define both 'modelFileName' and 'modelFileNamePattern'"
+            )
+
+        self.__dspec.modelFileName = self.__dspec_json.get("modelFileName")
+        self.__dspec.modelFileNamePattern = self.__dspec_json.get("modelFileNamePattern")
+
 
     def __parse_timing(self):
         # Grab timing info from dict
@@ -316,6 +335,7 @@ class Dspec:
         self.modelVersion = None
         self.author = None
         self.modelFileName = None
+        self.modelFileNamePattern = None
         
         self.outputInfo = None
         self.dependentSeries = []
@@ -324,7 +344,7 @@ class Dspec:
         self.timingInfo = None
 
     def __str__(self) -> str:
-        return f'[Dspec] -> modelName: {self.modelName}, modelVersion: {self.modelVersion}, author: {self.author}, modelFileName: {self.modelFileName}'
+        return f'[Dspec] -> modelName: {self.modelName}, modelVersion: {self.modelVersion}, author: {self.author}, modelFileName: {self.modelFileName}, modelFileNamePattern: {self.modelFileNamePattern}'
 
 class OutputInfo:
     '''OuputInfo object should contain everything that could be contained

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -58,10 +58,9 @@ class ModelRunner:
 
         # Use first model for shape (all models should match)
         expectedShape = models[0].input_shape
-        first_shape = models[0].input_shape
         
         for m in models:
-            if m.input_shape != first_shape:
+            if m.input_shape != expectedShape:
                 raise Semaphore_Exception("Model input shapes do not match")
             
         expectedShape = (len(input_vectors),) + expectedShape[1:]

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -17,61 +17,120 @@ from DataClasses import SemaphoreSeriesDescription, Series
 from utility import log, construct_true_path
 from exceptions import Semaphore_Exception
 from ModelExecution.dspecParser import Dspec
-
+import re
 import datetime
 from os import path, getenv
 from numpy import reshape
+import numpy as np
+import glob
 from tensorflow.keras.models import load_model
 
 
 class ModelRunner:
-     
 
     def make_predictions(self, DSPEC: Dspec, input_vectors: list[any], reference_time: datetime) -> Series:
-        """Computes a prediction but does not save it to persistent storage"""
+        """
+        This function runs predictions using one or multiple models and processes the results.
 
-        log('Init load model....')
-        model = self.__load_model(DSPEC.modelFileName)
+        - Loads model(s) based on the DSPEC configuration
+        - Reshapes input vectors to match the expected model input shape
+        - Runs predictions for each model using the same input data
+        - Stacks all model predictions into a single 3D array 
+        (models, input_vectors, outputs)
+        - Applies post-processing using the specified output handler
+        - Wraps the processed results into a Series object with metadata
+        - Returns the final Series containing the prediction results
+        """
+        log('Init load model(s)....')
+
+        models = self.__load_models(DSPEC)
 
         log('Init shape inputs....')
-        # The input vector(s) must be reshaped to match the model's input shape
-        # The first dimension of the expected shape is left None by TensorFlow 
-        # for us to fill in the amount of input vectors we are providing.
-        expectedShape = model.input_shape
-        expectedShape = (len(input_vectors),) + expectedShape[1:] 
-        shapedInputs = reshape(input_vectors, expectedShape) 
 
-        log('Init compute prediction....')
-        prediction =  model.predict(shapedInputs) 
+        # Use first model for shape (all models should match)
+        expectedShape = models[0].input_shape
+        first_shape = models[0].input_shape
+        
+        for m in models:
+            if m.input_shape != first_shape:
+                raise Semaphore_Exception("Model input shapes do not match")
+            
+        expectedShape = (len(input_vectors),) + expectedShape[1:]
+        shapedInputs = reshape(input_vectors, expectedShape)
+
+        log('Init compute predictions for all models....')
+
+        all_predictions = []
+
+        for model in models:
+            prediction = model.predict(shapedInputs)
+            all_predictions.append(prediction)
+
+        # Stack predictions → shape becomes (models, input_vectors, outputs)
+        stacked_predictions = np.stack(all_predictions, axis=0)
 
         log('Init prediction post process....')
-        #Instantiate the right output handler method then post process the predictions
-        OH_Class = output_handler_factory(DSPEC.outputInfo.outputMethod)
-        processedOutputs = OH_Class.post_process_prediction(prediction, DSPEC, reference_time) 
 
-        #Put the post processed predictions in a series
+        OH_Class = output_handler_factory(DSPEC.outputInfo.outputMethod)
+        processedOutputs = OH_Class.post_process_prediction(
+            stacked_predictions, DSPEC, reference_time
+        )
+
         series = Series(
-            description= SemaphoreSeriesDescription(
-                modelName=      DSPEC.modelName, 
-                modelVersion=   DSPEC.modelVersion, 
-                dataSeries=     DSPEC.outputInfo.series, 
-                dataLocation=   DSPEC.outputInfo.location, 
-                dataDatum=      DSPEC.outputInfo.datum
+            description=SemaphoreSeriesDescription(
+                modelName=DSPEC.modelName,
+                modelVersion=DSPEC.modelVersion,
+                dataSeries=DSPEC.outputInfo.series,
+                dataLocation=DSPEC.outputInfo.location,
+                dataDatum=DSPEC.outputInfo.datum
             )
         )
-        series.dataFrame= processedOutputs
 
+        series.dataFrame = processedOutputs
         return series
     
 
-    def __load_model(self, modelPath) -> None:
-        """Private method to load a model saves as an h5 file designated
-        in the dspec file using Tenserflow/Karas
-        """
-        h5FilePath = construct_true_path(getenv('MODEL_FOLDER_PATH')) + (modelPath if modelPath.endswith('.h5') else modelPath + '.h5')
-
-        if not path.exists(h5FilePath): 
-            raise Semaphore_Exception(f'H5 file for {modelPath} not found at {h5FilePath}!')
+    def __load_models(self, DSPEC: Dspec):
+        """Loads either a single model or multiple models based on the Dspec"""
         
-        return load_model(h5FilePath, compile=False)
+        base_path = construct_true_path(getenv('MODEL_FOLDER_PATH'))
+
+        # Multi-model (CRPS)
+        if DSPEC.modelFileNamePattern:
+            pattern = base_path + DSPEC.modelFileNamePattern
+            files = glob.glob(pattern)
+            files.sort(key=self.extract_number)  # Ensure consistent ordering
+
+            if not files:
+                raise Semaphore_Exception(f"No models found for pattern: {pattern}")
+
+            models = [load_model(f, compile=False) for f in files]
+            return models
+
+        # Single model
+        elif DSPEC.modelFileName:
+            model_path = DSPEC.modelFileName
+
+            # Ensure .h5 extension
+            if not model_path.endswith('.h5'):
+                model_path += '.h5'
+
+            full_path = base_path + model_path
+
+            if not path.exists(full_path):
+                raise Semaphore_Exception(
+                    f'H5 file for {model_path} not found at {full_path}!'
+                )
+
+            model = load_model(full_path, compile=False)
+            return [model]
+
+        else:
+            raise Semaphore_Exception(
+                "No modelFileName or modelFileNamePattern provided"
+            )
     
+    def extract_number(self, filename):
+        match = re.search(r'\d+', filename)
+        return int(match.group()) if match else float('inf')
+

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -44,7 +44,16 @@ class ModelRunner:
         log('Init load model(s)....')
 
         models = self.__load_models(DSPEC)
+        expectedMemberCount = DSPEC.outputInfo.expectedOutputShape.memberCount
+        # Validate model count matches expected member count
 
+        log(f"Loaded {len(models)} models, expected {expectedMemberCount}")
+
+        if len(models) != expectedMemberCount:
+            raise Semaphore_Exception(
+                f"Expected {expectedMemberCount} model(s) based on DSPEC, but found {len(models)}"
+            )
+        
         log('Init shape inputs....')
 
         # Use first model for shape (all models should match)

--- a/src/tests/UnitTests/test_modelRunner.py
+++ b/src/tests/UnitTests/test_modelRunner.py
@@ -22,7 +22,7 @@ from numpy import float32
 import types
 
 from src.ModelExecution.modelRunner import ModelRunner
-from src.ModelExecution.dspecParser import Dspec, OutputInfo
+from src.ModelExecution.dspecParser import Dspec, OutputInfo, ExpectedOutputShape
 from src.DataClasses import Series, SemaphoreSeriesDescription
 from exceptions import Semaphore_Exception
 
@@ -46,6 +46,10 @@ def mock_dspec(multi=False):
     outputInfo.interval = 3600
     outputInfo.datum = 'testDatum'
     outputInfo.unit = 'testUnit'
+    eos = ExpectedOutputShape()
+    eos.memberCount = 3 if multi else 1
+    outputInfo.expectedOutputShape = eos
+
 
     dspec = Dspec()
     dspec.outputInfo = outputInfo

--- a/src/tests/UnitTests/test_modelRunner.py
+++ b/src/tests/UnitTests/test_modelRunner.py
@@ -15,112 +15,231 @@ import sys
 sys.path.append('/app/src')
 
 from datetime import datetime, timezone
-import sys
 import pytest
 from unittest.mock import MagicMock, patch
+import numpy as np
+from numpy import float32
+import types
+
 from src.ModelExecution.modelRunner import ModelRunner
 from src.ModelExecution.dspecParser import Dspec, OutputInfo
 from src.DataClasses import Series, SemaphoreSeriesDescription
-from numpy import array, float32
+from exceptions import Semaphore_Exception
+
+
+# -------------------------------
+# Helpers
+# -------------------------------
 
 def mock_outputHandlerFactory(mocked_returnClass: MagicMock):
-    # The mock factory should return a mock class
     mock_factory = MagicMock()
     mock_factory.return_value = mocked_returnClass
     return mock_factory
 
-def mock_dspec():
-    """ This fixture returns a mock dspec object with a single dependent series and a single post process call
-    """
+
+def mock_dspec(multi=False):
     outputInfo = OutputInfo()
     outputInfo.outputMethod = 'TestOutputMethod'
     outputInfo.leadTime = 3600
     outputInfo.series = 'testSeries'
     outputInfo.location = 'testLocation'
     outputInfo.interval = 3600
-    outputInfo.fromDateTime = None
-    outputInfo.toDateTime = None
     outputInfo.datum = 'testDatum'
     outputInfo.unit = 'testUnit'
 
-
     dspec = Dspec()
     dspec.outputInfo = outputInfo
-    dspec.modelFileName = 'test_AI'
     dspec.modelName = 'testModelName'
     dspec.modelVersion = '0.0.0'
+
+    if multi:
+        dspec.modelFileNamePattern = 'mock_pattern'
+    else:
+        dspec.modelFileName = 'test_AI'
 
     return dspec
 
 
+def mock_models_with_order(num_models, num_outputs=5):
+    """Models return DISTINCT outputs with multiple outputs"""
+    models = []
+
+    for i in range(num_models):
+        mock_model = MagicMock()
+        mock_model.input_shape = (None, 87)
+
+        def make_predict(val):
+            def predict(inputs):
+                batch_size = len(inputs)
+                row = [val + j for j in range(num_outputs)]
+                return np.array([row] * batch_size, dtype=float32)
+            return predict
+
+        mock_model.predict.side_effect = make_predict(i + 1)
+        models.append(mock_model)
+
+    return models
+
+
 def equate_series(left: Series, right: Series):
-    """Compares two series objects against one another"""
+    assert left.dataFrame == right.dataFrame
 
-    assert left.dataFrame == right.dataFrame, "Series data does not match"
-    
-    leftD = left.description
-    rightD = right.description
-    assert leftD.dataSeries == rightD.dataSeries, "Series descriptions do not match"
-    assert leftD.modelName == rightD.modelName, "Model names do not match"
-    assert leftD.modelVersion == rightD.modelVersion, "Model versions do not match"
-    assert leftD.dataSeries == rightD.dataSeries, "Series names do not match"
-    assert leftD.dataLocation == rightD.dataLocation, "Locations do not match"
-    assert leftD.dataDatum == rightD.dataDatum, "Datums do not match"
+    assert left.description.modelName == right.description.modelName
+    assert left.description.modelVersion == right.description.modelVersion
+    assert left.description.dataSeries == right.description.dataSeries
+    assert left.description.dataLocation == right.description.dataLocation
+    assert left.description.dataDatum == right.description.dataDatum
 
 
+# -------------------------------
+# Test Data
+# -------------------------------
 
-TEST_DSPEC = mock_dspec()
 TEST_REF_TIME = datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-TEST_DESCRIPTION = SemaphoreSeriesDescription(
-    'testModelName',
-    '0.0.0',
-    'testSeries',
-    'testLocation',
-    'testDatum'
+
+TEST_SERIES = Series(
+    SemaphoreSeriesDescription(
+        'testModelName',
+        '0.0.0',
+        'testSeries',
+        'testLocation',
+        'testDatum'
+    )
 )
-TEST_SERIES = Series(TEST_DESCRIPTION)
 RESULT_DATA = 0
 TEST_SERIES.dataFrame = RESULT_DATA
 
-SINGLE_VECTOR = [[num for num in range(87)]]
-SINGLE_VECTOR_EXPECTED_OUTPUT = array([[[0.7075105]]], dtype=float32)
-MULTI_VECTOR = [[num for num in range(87)], [num for num in range(87)]]
-MULTI_VECTOR_EXPECTED_OUTPUT = array([[[0.7075105], [0.7075105]]], dtype=float32)
+SINGLE_VECTOR = [[i for i in range(87)]]
+
+# MUST BE 3 for (3,3,5)
+MULTI_VECTOR = [
+    [i for i in range(87)],
+    [i for i in range(87)],
+    [i for i in range(87)]
+]
 
 
-# docker exec semaphore-core python3 -m pytest src/tests/UnitTests/test_modelRunner.py
-@pytest.mark.parametrize("dspec , input_vectors, reference_time, expected_outputHandlerCall, expected_series", [
-    (TEST_DSPEC, SINGLE_VECTOR, TEST_REF_TIME, (SINGLE_VECTOR_EXPECTED_OUTPUT, TEST_DSPEC, TEST_REF_TIME), TEST_SERIES), # Tests running a single model
-    (TEST_DSPEC, MULTI_VECTOR, TEST_REF_TIME, (MULTI_VECTOR_EXPECTED_OUTPUT, TEST_DSPEC, TEST_REF_TIME), TEST_SERIES), # Tests running an ensemble 
-])
-def test_make_predictions(dspec: Dspec, input_vectors:list[any], reference_time: datetime, expected_outputHandlerCall, expected_series):
-    """ This tests the make_predictions method of the modelRunner class.
+# -------------------------------
+# Main Test
+# -------------------------------
 
-    :param dspec: Dspec - The dspec to reference.
-    :param input_vectors: list[any] - The input vectors to be used for predictions.
-    :param reference_time: datetime - The reference time for the predictions.
-    :param expected_outputHandlerCall: The expected arguments to be passed to the output handler's post_process_prediction method.
-    :param expected_series: The expected series to be returned by the make_predictions method.
-    """
+@pytest.mark.parametrize(
+    "multi, input_vectors, expected_shape",
+    [
+        (False, SINGLE_VECTOR, (1, 1, 5)),
+        (False, MULTI_VECTOR, (1, 3, 5)),
+        (True, SINGLE_VECTOR, (3, 1, 5)),
+        (True, MULTI_VECTOR, (3, 3, 5)),  
+    ]
+)
+def test_make_predictions(multi, input_vectors, expected_shape):
 
-    # We create an output handler mock so we can read what gets passed to it
     OH_MOCK = MagicMock()
-    OH_MOCK.post_process_prediction.return_value = RESULT_DATA # We don't care what it returns as its out of scope for this unit
+    OH_MOCK.post_process_prediction.return_value = RESULT_DATA
 
-    # Patch out the output handler factory forcing it to return our mocked output handler class
-    with patch('src.ModelExecution.modelRunner.output_handler_factory', mock_outputHandlerFactory(OH_MOCK)):
+    with patch('src.ModelExecution.modelRunner.output_handler_factory',
+               mock_outputHandlerFactory(OH_MOCK)):
 
-        modelRunner = ModelRunner()
-        result_series = modelRunner.make_predictions(dspec, input_vectors, reference_time)
+        with patch.object(ModelRunner, "_ModelRunner__load_models") as mock_loader:
 
-    # Checking the call to the mocked OH class. There is a method does this for us:
-    # --> OH_MOCK.post_process_prediction.assert_called_once_with(*expected_outputHandlerCall)
-    # However this method throws up due to the call containing multi value numpy arrays
-    # so I wrote out the logic below.  
-    assert OH_MOCK.post_process_prediction.call_count == 1, 'Call to OutputHandler.post_process_prediction called more than once!'
-    actual_args = OH_MOCK.post_process_prediction.call_args.args
-    assert (abs(expected_outputHandlerCall[0] - actual_args[0]) < 1e-6).all(), 'Call to OutputHandler.post_process_prediction had incorrect predictions!'
-    assert expected_outputHandlerCall[1:] == actual_args[1:],  'Call to OutputHandler.post_process_prediction had incorrect arguments!'
+            num_models = 3 if multi else 1
+            mock_loader.return_value = mock_models_with_order(num_models)
 
-    # Check the series returned is correct
-    equate_series(result_series, expected_series)
+            runner = ModelRunner()
+            result_series = runner.make_predictions(
+                mock_dspec(multi),
+                input_vectors,
+                TEST_REF_TIME
+            )
+
+    predictions = OH_MOCK.post_process_prediction.call_args.args[0]
+
+    print("TEST SHAPE:", predictions.shape)
+    print("PREDICTIONS:", predictions)
+
+    # -------------------------------
+    # Shape checks
+    # -------------------------------
+    assert predictions.shape == expected_shape
+    assert predictions.shape[2] == 5
+
+    # -------------------------------
+    # Value checks (critical)
+    # -------------------------------
+    if multi:
+        for m in range(num_models):
+            expected = [m + 1 + j for j in range(5)]
+            for i in range(len(input_vectors)):
+                assert list(predictions[m, i]) == expected
+    else:
+        expected = [1 + j for j in range(5)]
+        for i in range(len(input_vectors)):
+            assert list(predictions[0, i]) == expected
+
+    equate_series(result_series, TEST_SERIES)
+
+
+# -------------------------------
+# Order Test
+# -------------------------------
+
+def test_model_loading_order():
+
+    OH_MOCK = MagicMock()
+    OH_MOCK.post_process_prediction.return_value = RESULT_DATA
+
+    with patch('src.ModelExecution.modelRunner.output_handler_factory',
+               mock_outputHandlerFactory(OH_MOCK)):
+
+        with patch.object(ModelRunner, "_ModelRunner__load_models") as mock_loader:
+
+            mock_loader.return_value = mock_models_with_order(3)
+
+            runner = ModelRunner()
+            runner.make_predictions(
+                mock_dspec(multi=True),
+                SINGLE_VECTOR,
+                TEST_REF_TIME
+            )
+
+    predictions = OH_MOCK.post_process_prediction.call_args.args[0]
+
+    assert list(predictions[:, 0, 0]) == [1, 2, 3]
+
+
+# -------------------------------
+# __load_models Tests
+# -------------------------------
+
+@patch('src.ModelExecution.modelRunner.glob.glob')
+@patch('src.ModelExecution.modelRunner.load_model')
+def test_load_models_sorted(mock_load_model, mock_glob):
+
+    mock_glob.return_value = ['model_3.h5', 'model_1.h5', 'model_2.h5']
+    mock_load_model.side_effect = lambda f, compile=False: f
+
+    models = ModelRunner()._ModelRunner__load_models(mock_dspec(multi=True))
+
+    assert models == ['model_1.h5', 'model_2.h5', 'model_3.h5']
+
+
+@patch('src.ModelExecution.modelRunner.load_model')
+@patch('src.ModelExecution.modelRunner.glob.glob')
+def test_load_models_from_pattern(mock_glob, mock_load_model):
+
+    mock_glob.return_value = [
+        '/models/model_2.h5',
+        '/models/model_1.h5',
+        '/models/model_3.h5'
+    ]
+
+    mock_load_model.side_effect = lambda f, compile=False: f"LOADED::{f}"
+
+    models = ModelRunner()._ModelRunner__load_models(mock_dspec(multi=True))
+
+    assert models == [
+        'LOADED::/models/model_1.h5',
+        'LOADED::/models/model_2.h5',
+        'LOADED::/models/model_3.h5'
+    ]
+


### PR DESCRIPTION
## Objective
Enable multi-member model execution in `ModelRunner` by:
- Ensuring the number of loaded models matches the number of members defined in the DSPEC  
- Iterating through each model to generate and stack prediction outputs  

---

## Changes

### DSPEC Parser
- Added an optional field `modelFileNamePattern` to support multi-model configurations  
- Usage:
  - `modelFileName` → for single-model DSPECs  
  - `modelFileNamePattern` → for multi-model DSPECs  

### ModelRunner
- Updated logic to support both single-model and multi-model runs
- Implemented loop over multiple models and stacking of prediction outputs  

---

## How to Test
```bash
docker compose up -d --build
docker exec semaphore-core python -m pytest -s
```
## Note:
Feel free to run models, but it will fail at output handler since it expects 2d arrays at the moment. I added print statements before output handler to confirm the correct output.  


Results from print statements in model runner:

# Test Results
<img width="201" height="254" alt="Screenshot 2026-03-25 100030" src="https://github.com/user-attachments/assets/480cdf63-f0a2-4979-ac65-919210f96cfa" />
<img width="190" height="129" alt="Screenshot 2026-03-25 100045" src="https://github.com/user-attachments/assets/56cb0fde-4c04-4b62-9b80-986b719cd4cf" />

# 24 hr Cold stunning models
<img width="174" height="79" alt="Screenshot 2026-03-25 092400" src="https://github.com/user-attachments/assets/be6d0723-8545-422a-a7b8-0cc976c5afc2" />
<img width="172" height="1170" alt="Screenshot 2026-03-25 092444" src="https://github.com/user-attachments/assets/a108db12-afc4-493c-af8a-ab463502ed97" />
