### PR TITLE
Fixing 500 when no data is returned

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -234,6 +234,13 @@ def serialize_series(series: Series) -> dict[any]:
 
     if series is None:
         return dict()
+    
+    if series.dataFrame is None:
+        # In this case we have no data to serialize but we still want to return the description and time description
+        serialized = jsonable_encoder(series, exclude={'_Series__dataFrame'})
+        serialized['isComplete'] = True # Ensure isComplete always exists for backward compatibility
+        serialized['_Series__data'] = [] # Ensure data always exists for backward compatibility
+        return serialized
 
     if isinstance(series.description, SemaphoreSeriesDescription):
         return serialize_output_series(series)


### PR DESCRIPTION
## What?
The serializer was causing a 500 when it received a series with dataFrame set to None
series.dataFrame was being set to None when no data was found for a query.

## Fix:
I added a case to the serializer for is the series exists but the data frame doesnt, it serializes an empty data field.

## Test
1. `docker compose up --build -d`
2. curl curl http://localhost:8888/output/modelName=ar_inundation_mar_24h/modelVersion=1.0.0/series=pInundation/location=Aransas/fromDateTime=2026033102/toDateTime=2026033113?interval=3600
3. See no 500