### PR TITLE
905 change thermal refuge cron schedule

### DIFF
--- a/data/dspec/TestModels/test_invalidVectorOrder.json
+++ b/data/dspec/TestModels/test_invalidVectorOrder.json
@@ -5,7 +5,7 @@
             "author": "John Doe",
             "modelFileName": "test_AI",
             "timingInfo": {
-                "active": "False",
+                "active": false,
                 "offset": 0,
                 "interval": 3600
             },

--- a/data/dspec/ThermalRefuge.json
+++ b/data/dspec/ThermalRefuge.json
@@ -6,7 +6,7 @@
     "modelFileName": "thermalrefugemodel",
     "timingInfo": {
         "active": true,
-        "offset": 0,
+        "offset": 1620,
         "interval": 3600
     },
     "outputInfo": {

--- a/data/dspec/comment.json
+++ b/data/dspec/comment.json
@@ -1,3 +1,3 @@
 {
-    "comment": "The MLP-OP model running every three hours with a ten minute offset AND the Thermal Refuge model running every hour with a zero minute offset."
+    "comment": "The MLP-OP model running every three hours with a ten minute offset AND the Thermal Refuge model running every hour with a twenty seven minute offset."
 }


### PR DESCRIPTION
A small change to runt he thermal refuge model 27 minutes past the hour. 

To Test: 
- activate WSL 
- run `python3 tools/init_cron.py -r ./data/dspec -i ./schedule`
- check the crontab created: `crontab -l`
- check that thermal refuge is set to run 27 minutes past the hour rather than 0