### PR TITLE
adding interpolation to semaphore series

### DIFF
--- a/data/dspec/Magnolia/12/magnolia_transform_12.json
+++ b/data/dspec/Magnolia/12/magnolia_transform_12.json
@@ -27,7 +27,15 @@
             "interval": 3600,
             "range":  [7, -5],
             "outKey": "MG_12_output_12",
-            "stalenessOffset": 45000
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "3600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
         },
         { 
             "_name": "Wind Direction Prediction",

--- a/data/dspec/Magnolia/24/magnolia_transform_24.json
+++ b/data/dspec/Magnolia/24/magnolia_transform_24.json
@@ -27,7 +27,15 @@
             "interval": 3600,
             "range":  [19, 7],
             "outKey": "MG_24_output_12",
-            "stalenessOffset": 45000
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "3600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
         },
         { 
             "_name": "Wind Direction Prediction",

--- a/data/dspec/Magnolia/48/magnolia_transform_48.json
+++ b/data/dspec/Magnolia/48/magnolia_transform_48.json
@@ -27,7 +27,15 @@
             "interval": 3600,
             "range":  [43, 31],
             "outKey": "MG_48_output_48",
-            "stalenessOffset": 45000
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "3600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
         },
         { 
             "_name": "Wind Direction Prediction",


### PR DESCRIPTION
A small change to add interpolation to the Semaphore series that the magnolia transform models ingests. 

There isn't a great way to test this but what I did was run the base magnolia model once and then the transform to see that interpolation kicked off for that series.

<img width="2312" height="780" alt="image" src="https://github.com/user-attachments/assets/53051101-8516-4be4-8c91-4e6e0cf2e015" />

Test: 

1. build containers `docker compose up -d --build`
2. run base magnolia model `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Magnolia/12/magnolia_12.json -v`
3. run transform `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Magnolia/12/magnolia_transform_12.json -v`