### PR TITLE
date range clipping in validation according to model needs

### DIFF
--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float", 
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",     "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",     "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25", "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25", "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",     "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",     "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25", "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25", "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F7", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F7", "dType": "float" }
     ]

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F20", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F20", "dType": "float" }
     ]

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F43", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F43", "dType": "float" }
     ]

--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -46,36 +46,20 @@ class DateRangeValidation(IDataValidation):
         # The original must stay intact — buffer slots outside the indexed window
         # are still valid data we want to store.
         df_to_validate = series.dataFrame.copy()
-
-        # --- Clipping ---
-        # If vectorOrder indexes were provided, clip the dataframe to only the rows
-        # the model actually reads. Buffer slots outside this window are intentionally
-        # excluded — their absence should not cause validation to fail.
+        
         if self.indexes is not None:
-            # Unpack: min_index is the closest-to-now slot (right/future side),
-            # max_index is the furthest-from-now slot (left/past side).
             min_index, max_index = self.indexes
+            df_to_validate = df_to_validate.iloc[min_index:max_index]
 
-            # The dataframe is ordered oldest → newest after the reindex in DataGatherer.
-            # -(max_index + 1) counts back from the end to include the furthest past slot.
-            # e.g. max_index=25 → iloc[-26:] keeps the 26 model-read rows from the left.
-            clip_start = -(max_index + 1)
-
-            # len(df) - min_index trims future buffer rows from the right.
-            # When min_index=0 this evaluates to len(df), i.e. no right-side trim.
-            # `or None` converts 0 → None so iloc doesn't produce an empty slice
-            # (iloc[x:0] is empty, iloc[x:None] goes to the end — which is what we want).
-            clip_end = len(df_to_validate) - min_index or None
-
-            df_to_validate = df_to_validate.iloc[clip_start:clip_end]
+            if len(df_to_validate) == 0:
+                log_error(f'DateRangeValidation: indexes={self.indexes} produced an empty clipped window for a dataframe of length {len(series.dataFrame)}')
+                return False
 
         # Set timeVerified as the index so we can reindex against an expected date range.
         df_to_validate.set_index('timeVerified', inplace=True)
-        
-        # --- Expected index ---
-        # When indexes are provided, bounds come from the clipped dataframe's actual
-        # timestamps — using timeDescription here would re-expand back to the full window.
-        # When indexes is None, use timeDescription bounds (original behavior) so that
+
+        # When indexes are provided use the clipped frame's actual bounds.
+        # When indexes is None use timeDescription bounds (original behavior) so
         # dataframes missing values at the edges relative to timeDescription still fail.
         if self.indexes is not None:
             expected_index = date_range(
@@ -89,7 +73,7 @@ class DateRangeValidation(IDataValidation):
                 end=series.timeDescription.toDateTime,
                 freq=timedelta(seconds=series.timeDescription.interval.total_seconds())
             )
-
+            
         # Reindex to the expected range — any genuinely missing interior timestamps
         # will become NaN rows, which we catch below.
         df_to_validate = df_to_validate.reindex(expected_index)

--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -21,8 +21,16 @@ from pandas import date_range
 
 class DateRangeValidation(IDataValidation):
 
-    def __init__(self, referenceTime: datetime = None):
+    def __init__(self, referenceTime: datetime = None, indexes: tuple[int, int] = None):
+        # referenceTime is used for the staleness check further below.
+        # It is None in unit tests and for series that don't need a staleness check.
         self.referenceTime = referenceTime
+
+        # indexes is the (min_index, max_index) from vectorOrder — the actual slots
+        # the model reads. e.g. (0, 25) for a 26-point model with a left buffer,
+        # or (1, 25) if there is also a right-side buffer.
+        # None means no buffer info was provided; validate the full window as-is.
+        self.indexes = indexes  
         
     def validate(self, series: Series) -> bool:
         """ This method checks for missing date ranges in the the expected time series. 
@@ -34,32 +42,73 @@ class DateRangeValidation(IDataValidation):
             log_error('DateRangeValidation: No data in series to validate.')
             return False # No data to validate
     
+        # Work on a copy so we never mutate the original series dataframe.
+        # The original must stay intact — buffer slots outside the indexed window
+        # are still valid data we want to store.
         df_to_validate = series.dataFrame.copy()
 
+        # --- Clipping ---
+        # If vectorOrder indexes were provided, clip the dataframe to only the rows
+        # the model actually reads. Buffer slots outside this window are intentionally
+        # excluded — their absence should not cause validation to fail.
+        if self.indexes is not None:
+            # Unpack: min_index is the closest-to-now slot (right/future side),
+            # max_index is the furthest-from-now slot (left/past side).
+            min_index, max_index = self.indexes
+
+            # The dataframe is ordered oldest → newest after the reindex in DataGatherer.
+            # -(max_index + 1) counts back from the end to include the furthest past slot.
+            # e.g. max_index=25 → iloc[-26:] keeps the 26 model-read rows from the left.
+            clip_start = -(max_index + 1)
+
+            # len(df) - min_index trims future buffer rows from the right.
+            # When min_index=0 this evaluates to len(df), i.e. no right-side trim.
+            # `or None` converts 0 → None so iloc doesn't produce an empty slice
+            # (iloc[x:0] is empty, iloc[x:None] goes to the end — which is what we want).
+            clip_end = len(df_to_validate) - min_index or None
+
+            df_to_validate = df_to_validate.iloc[clip_start:clip_end]
+
+        # Set timeVerified as the index so we can reindex against an expected date range.
         df_to_validate.set_index('timeVerified', inplace=True)
+        
+        # --- Expected index ---
+        # IMPORTANT: bounds must come from the clipped dataframe's actual timestamps,
+        # NOT from series.timeDescription.fromDateTime/toDateTime.
+        # timeDescription reflects the full over-requested window including buffer slots.
+        # Using it here would re-expand the index back to the full window, reintroducing
+        # NaNs for the buffer slots we just clipped — defeating the entire purpose.
         expected_index = date_range(
-            start=series.timeDescription.fromDateTime, 
-            end=series.timeDescription.toDateTime, 
+            start=df_to_validate.index[0],   # first timestamp in the clipped window
+            end=df_to_validate.index[-1],    # last timestamp in the clipped window
             freq=timedelta(seconds=series.timeDescription.interval.total_seconds())
         )
+
+        # Reindex to the expected range — any genuinely missing interior timestamps
+        # will become NaN rows, which we catch below.
         df_to_validate = df_to_validate.reindex(expected_index)
 
         # If there are still null values, then there are missing values
         missing_value_count = df_to_validate['dataValue'].isnull().sum()
-        
         if missing_value_count > 0:
+            if self.indexes is not None:
+                log_error(f'DateRangeValidation: indexes={self.indexes} — validated clipped window of {len(df_to_validate)} rows ({df_to_validate.index[0]} → {df_to_validate.index[-1]})')
+            else:
+                log_error(f'DateRangeValidation: no indexes provided — validated full window of {len(df_to_validate)} rows ({df_to_validate.index[0]} → {df_to_validate.index[-1]})')
             log_error(f'DateRangeValidation: Series {series} is missing {missing_value_count} values.')
             for missing_time in df_to_validate[df_to_validate['dataValue'].isnull()].index:
                 log_error(f'\tMissing time: {missing_time}')
             return False
-        # only unit tests will skip this check unless they set a reference time
-        # and measurements that do not have stalenessOffset set will skip this check
+        
+        # --- Staleness check ---
+        # Only unit tests will skip this check (referenceTime=None).
+        # Series without a stalenessOffset set also skip this check.
         if self.referenceTime is not None and series.timeDescription.stalenessOffset is not None:
-            # calculate time difference between reference time and earliest generated time
+            # Calculate time difference between reference time and earliest generated time
             time_difference = abs(self.referenceTime - df_to_validate['timeGenerated'].min())
 
-            # validate that the data isn't stale
-            # Note that staleness check is brittle for predictions.
+            # Validate that the data isn't stale.
+            # NOTE: that staleness check is brittle for predictions.
             # Do not modify unless you know what you are doing!!!!!
             if time_difference > series.timeDescription.stalenessOffset:
                 log_error(f'DateRangeValidation: Series {series} is stale.')

--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -73,16 +73,22 @@ class DateRangeValidation(IDataValidation):
         df_to_validate.set_index('timeVerified', inplace=True)
         
         # --- Expected index ---
-        # IMPORTANT: bounds must come from the clipped dataframe's actual timestamps,
-        # NOT from series.timeDescription.fromDateTime/toDateTime.
-        # timeDescription reflects the full over-requested window including buffer slots.
-        # Using it here would re-expand the index back to the full window, reintroducing
-        # NaNs for the buffer slots we just clipped — defeating the entire purpose.
-        expected_index = date_range(
-            start=df_to_validate.index[0],   # first timestamp in the clipped window
-            end=df_to_validate.index[-1],    # last timestamp in the clipped window
-            freq=timedelta(seconds=series.timeDescription.interval.total_seconds())
-        )
+        # When indexes are provided, bounds come from the clipped dataframe's actual
+        # timestamps — using timeDescription here would re-expand back to the full window.
+        # When indexes is None, use timeDescription bounds (original behavior) so that
+        # dataframes missing values at the edges relative to timeDescription still fail.
+        if self.indexes is not None:
+            expected_index = date_range(
+                start=df_to_validate.index[0],
+                end=df_to_validate.index[-1],
+                freq=timedelta(seconds=series.timeDescription.interval.total_seconds())
+            )
+        else:
+            expected_index = date_range(
+                start=series.timeDescription.fromDateTime,
+                end=series.timeDescription.toDateTime,
+                freq=timedelta(seconds=series.timeDescription.interval.total_seconds())
+            )
 
         # Reindex to the expected range — any genuinely missing interior timestamps
         # will become NaN rows, which we catch below.

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -59,7 +59,7 @@ class DataGatherer:
         # Build a lookup from outKey → indexes using orderedVector
         vector_index_lookup: dict[str, tuple[int, int]] = {}
         ordered_vector = getattr(dspec, 'orderedVector', None)
-        if ordered_vector is not None:
+        if ordered_vector is not None and hasattr(ordered_vector, 'keys'):
             vector_index_lookup = {
                 key: indexes
                 for key, indexes in zip(ordered_vector.keys, ordered_vector.indexes)

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -56,8 +56,18 @@ class DataGatherer:
         dependentSeries: list[DependentSeries] = dspec.dependentSeries
         postProcessCalls: list[PostProcessCall] = dspec.postProcessCall
 
+        # Build a lookup from outKey → indexes using orderedVector
+        vector_index_lookup: dict[str, tuple[int, int]] = {}
+        ordered_vector = getattr(dspec, 'orderedVector', None)
+        if ordered_vector is not None:
+            vector_index_lookup = {
+                key: indexes
+                for key, indexes in zip(ordered_vector.keys, ordered_vector.indexes)
+                if indexes != (None, None)  # (None, None) means no buffer info, skip
+            }
+
         # Get Dependent Data
-        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime)
+        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime, vector_index_lookup)
 
         # Call post processing 
         post_processed_series_repository = self.__post_process_data(dependent_data_repository, postProcessCalls)
@@ -65,7 +75,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime) -> dict[str, Series]:
+    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, vector_index_lookup: dict[str, tuple[int, int]] = {}) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description
@@ -119,8 +129,12 @@ class DataGatherer:
             # Reset the index
             series.dataFrame.reset_index(inplace=True)
 
+            # Look up the vectorOrder indexes for this series by outKey.
+            # None means this series has no vectorOrder entry — validate the full window.
+            indexes = vector_index_lookup.get(key, None)
+
             # Validate the data
-            self.__validate_series(series, referenceTime)
+            self.__validate_series(series, referenceTime, indexes)
             
             # Store the series in the repository
             series_repository[key] = series
@@ -210,13 +224,15 @@ class DataGatherer:
                             dependentSeries.dataIntegrityCall.args
                     )
     
-    def __validate_series(self, series: Series, referenceTime: datetime):
+    def __validate_series(self, series: Series, referenceTime: datetime, indexes: tuple[int, int] = None):
         """ This method checks if the series description has a verification override.
             If it does, it uses the override to validate the series.
             If it doesn't, it uses the date range validation to validate the series.
 
             :param series: Series - The series to validate
             :param referenceTime: datetime - The reference time for this model
+            :param indexes: tuple[int, int] - Optional (min, max) vectorOrder indexes; 
+                        if provided, validation is clipped to only what the model reads
         """
 
         if series.description.verificationOverride is not None:
@@ -227,7 +243,7 @@ class DataGatherer:
                 raise Semaphore_Data_Exception(f'OverrideValidation Failed in Data Gatherer! \n[Series] -> {series}')
         else:
             # if no verification override, default to validate the date range
-            is_valid = data_validation_factory('DateRangeValidation', referenceTime = referenceTime).validate(series)
+            is_valid = data_validation_factory('DateRangeValidation', referenceTime = referenceTime, indexes=indexes).validate(series)
 
             if not is_valid:
                 raise Semaphore_Data_Exception(f'DateRangeValidation Failed in Data Gatherer! \n[Series] -> {series}')

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -75,7 +75,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, vector_index_lookup: dict[str, tuple[int, int]] = {}) -> dict[str, Series]:
+    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, vector_index_lookup: dict[str, tuple[int, int]] = None) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description
@@ -97,6 +97,7 @@ class DataGatherer:
         """
         
         series_repository: dict[str, Series] = {}
+        vector_index_lookup = vector_index_lookup if vector_index_lookup is not None else {} 
 
         for dependentSeries in dependentSeriesList:
             

--- a/src/tests/UnitTests/test_DateRangeValidation.py
+++ b/src/tests/UnitTests/test_DateRangeValidation.py
@@ -325,7 +325,62 @@ class TestDateRangeValidation(unittest.TestCase):
 
         validator = data_validation_factory('DateRangeValidation', referenceTime=reference_time)
 
-        self.assertTrue(validator.validate(series_mock))   
+        self.assertTrue(validator.validate(series_mock)) 
+
+    def test_validate_indexes_missing_value_outside_window_passes(self):
+        """Asserts validate returns True when a missing value falls outside the indexed window.
+
+        The indexed window defines which rows the model actually reads. Any missing values
+        outside that window are buffer slots and should be ignored by validation.
+
+        Setup: 10 rows, indexes=(2, 8) → model reads rows 2-7.
+        Rows 0, 1 (left buffer) and rows 8, 9 (right buffer) are outside the window.
+        Missing values in those buffer slots should not cause validation to fail.
+        """
+        times = pd.date_range(start='2023-01-01 00:00', periods=10, freq='1h', tz='UTC')
+
+        # Put missing values in both buffer zones — rows 0, 1 and rows 8, 9
+        # Rows 2-7 (the model window) are all present
+        values = [None, None] + [float(i) for i in range(2, 8)] + [None, None]
+        df = pd.DataFrame({'timeVerified': times, 'dataValue': values})
+
+        series_mock = MagicMock()
+        series_mock.dataFrame = df
+        series_mock.timeDescription = MagicMock()
+        series_mock.timeDescription.fromDateTime = times[0]
+        series_mock.timeDescription.toDateTime = times[-1]
+        series_mock.timeDescription.interval = timedelta(hours=1)
+        series_mock.timeDescription.stalenessOffset = None
+
+        validator = DateRangeValidation(indexes=(2, 8))
+        self.assertTrue(validator.validate(series_mock))
+
+    def test_validate_indexes_missing_value_inside_window_fails(self):
+        """Asserts validate returns False when a missing value falls inside the indexed window.
+
+        A missing value inside the model window means the model would receive a NaN —
+        validation must catch this regardless of whether buffer slots are present or not.
+
+        Setup: 10 rows, indexes=(2, 8) → model reads rows 2-7.
+        Row 5 (interior to the model window) is missing — validation should fail.
+        """
+        times = pd.date_range(start='2023-01-01 00:00', periods=10, freq='1h', tz='UTC')
+
+        # All buffer slots present, but row 5 is missing inside the model window
+        values = [float(i) for i in range(10)]
+        values[5] = None
+        df = pd.DataFrame({'timeVerified': times, 'dataValue': values})
+
+        series_mock = MagicMock()
+        series_mock.dataFrame = df
+        series_mock.timeDescription = MagicMock()
+        series_mock.timeDescription.fromDateTime = times[0]
+        series_mock.timeDescription.toDateTime = times[-1]
+        series_mock.timeDescription.interval = timedelta(hours=1)
+        series_mock.timeDescription.stalenessOffset = None
+
+        validator = DateRangeValidation(indexes=(2, 8))
+        self.assertFalse(validator.validate(series_mock))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Lighthouse Haunted Data Gap Fix #919

**What was changed**

This PR fixes the "haunted gap" failures we were seeing on Bird Island and any other model that over-requests data to support interpolation buffering. `DateRangeValidation` was validating the entire requested window including buffer slots that the model never actually reads. When a Lighthouse sensor dropout landed exactly on `fromDateTime` (the buffer slot), it would fail validation even though the model would have run fine without that point. The fix passes `vectorOrder` indexes into the validation step so `DateRangeValidation` only checks the slots the model actually reads. The original series is never mutated.

Changes:
- `dataGatherer.py` — builds a `{outKey: (min_index, max_index)}` lookup from `dspec.orderedVector` at the top of `get_data_repository` and threads it down to `__validate_series`
- `DateRangeValidation.py` — accepts optional `indexes: tuple[int, int]`; if provided, clips the dataframe to model-read rows only before building the expected index. Error logging now fires next to the failure and includes the validated window bounds and whether indexes were applied.

**To Test**

1. `docker compose up --build -d`
2. `docker exec semaphore-core python3 -m pytest`
3. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr -v`

**Other things to validate**

- Confirm the vector builder logs `amnt_found: 27, indexed_len: 25` for the Bird Island water/air temp series — this means 27 rows were fetched, the buffer was clipped, and 25 were validated
- Confirm models without `vectorOrder` entries still run normally 
- If you think there was a better way to do this.... let me know. 