### PR TITLE
using overreturned values to estimate now point and test

### DIFF
--- a/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
+++ b/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
@@ -81,7 +81,7 @@ class LIGHTHOUSE(IDataIngestion):
         # These are only used to estimate the now-point if it's missing — they
         # never enter the series directly.
         extendedToDateTime = timeDescription.toDateTime + timedelta(hours=1)
-        toString = timeDescription.toDateTime.strftime('%m/%d/%y').replace('/', '%2F')
+        toString = extendedToDateTime.strftime('%m/%d/%y').replace('/', '%2F')
         
         ### Find what LIGHTHOUSE calls the series we want
         # SIM = series info map

--- a/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
+++ b/src/DataIngestion/DI_Classes/LIGHTHOUSE.py
@@ -16,7 +16,7 @@ from DataClasses import Series, SeriesDescription, get_input_dataFrame, TimeDesc
 from DataIngestion.IDataIngestion import IDataIngestion
 from utility import log
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from urllib.error import HTTPError
 from urllib.request import urlopen
 import json
@@ -75,6 +75,12 @@ class LIGHTHOUSE(IDataIngestion):
         
         # Reformat and sterilize datetimes
         fromString = timeDescription.fromDateTime.strftime('%m/%d/%y').replace('/', '%2F')
+        
+        # Extend the fetch window 1 hour past toDateTime to capture any 6-minute
+        # readings Lighthouse has published since the last hourly aggregate.
+        # These are only used to estimate the now-point if it's missing — they
+        # never enter the series directly.
+        extendedToDateTime = timeDescription.toDateTime + timedelta(hours=1)
         toString = timeDescription.toDateTime.strftime('%m/%d/%y').replace('/', '%2F')
         
         ### Find what LIGHTHOUSE calls the series we want
@@ -120,27 +126,52 @@ class LIGHTHOUSE(IDataIngestion):
         is_prediction = seriesDescription.dataSeries[0] == 'p'
         now_time = datetime.now(timezone.utc) if is_prediction else None
         
+        # Collect any sub-hourly readings past toDateTime separately.
+        # These are candidates for estimating the now-point if it's missing.
+        sub_hourly_values = []
+
         for dataPoint in data:
-         # Lighthouse returns epoch time in milliseconds
-            epochTimeStamp = dataPoint[dataTimestampIndex]/1000            # Lighthouse over returns data, so we just clip any data that is before or after our requested date range
-            if epochTimeStamp > timeDescription.toDateTime.timestamp() or epochTimeStamp < timeDescription.fromDateTime.timestamp():
+            epochTimeStamp = dataPoint[dataTimestampIndex] / 1000
+
+            if dataPoint[dataValueIndex] is None:
                 continue
 
             dt = datetime.fromtimestamp(epochTimeStamp, tz=timezone.utc)
 
-            if dataPoint[dataValueIndex] == None: # If lighthouse does not have a requested value, it will return None
+            # Readings past toDateTime go into the sub-hourly bucket, not the series
+            if epochTimeStamp > timeDescription.toDateTime.timestamp():
+                sub_hourly_values.append(dataPoint[dataValueIndex])
                 continue
 
-            # Use now_time for prediction series, otherwise use dt
+            # Clip anything before fromDateTime as before
+            if epochTimeStamp < timeDescription.fromDateTime.timestamp():
+                continue
+
             time_generated = now_time if is_prediction else dt
-            
             df.loc[len(df)] = [
-                dataPoint[dataValueIndex],          # dataValue
-                seriesInfoMap[SIMSeriesUnitIndex],  # dataUnit
-                dt,                                 # timeVerified
-                time_generated,                     # timeGenerated
-                lon,                                # longitude
-                lat                                 # latitude
+                dataPoint[dataValueIndex],
+                seriesInfoMap[SIMSeriesUnitIndex],
+                dt,
+                time_generated,
+                lon,
+                lat
+            ]
+
+        # --- Now-point estimation ---
+        # If the now-point (toDateTime) is missing from the series but we have
+        # sub-hourly readings from the extended window, average them as an estimate.
+        # timeGenerated is set to now so downstream staleness checks know when this was derived.
+        now_point_present = not df.empty and (df['timeVerified'] == timeDescription.toDateTime).any()
+        if not now_point_present and len(sub_hourly_values) >= 1:
+            estimated_value = sum(sub_hourly_values) / len(sub_hourly_values)
+            log(f'LIGHTHOUSE | now-point missing, estimating from {len(sub_hourly_values)} sub-hourly reading(s): {estimated_value:.4f}')
+            df.loc[len(df)] = [
+                estimated_value,
+                seriesInfoMap[SIMSeriesUnitIndex],
+                timeDescription.toDateTime,         # timeVerified = the now-point slot
+                datetime.now(timezone.utc),         # timeGenerated = when we derived it
+                lon,
+                lat
             ]
 
         if(len(df) > 0):

--- a/src/tests/IntegrationTests/test_LIGHTHOUSE.py
+++ b/src/tests/IntegrationTests/test_LIGHTHOUSE.py
@@ -23,6 +23,7 @@ from src.DataClasses import TimeDescription, SeriesDescription, Series
 from src.DataIngestion.IDataIngestion import data_ingestion_factory
 from src.DataIngestion.DI_Classes.LIGHTHOUSE import LIGHTHOUSE
 from dotenv import load_dotenv
+from unittest.mock import patch
 
 @pytest.mark.slow
 
@@ -131,4 +132,82 @@ def test_prediction_timeGenerated_is_current():
     assert ingestion_time != first_verified_time, (
         f"timeGenerated ({ingestion_time}) should not equal timeVerified ({first_verified_time}) "
         f"for prediction series — timeGenerated should reflect ingestion time, not the historical verified time"
+    )
+
+def test_now_point_estimated_from_sub_hourly_data():
+    """Tests that when the now-point (toDateTime) is missing from Lighthouse's hourly data,
+    the ingestion class synthesizes it by averaging any sub-hourly readings published
+    in the extended fetch window past toDateTime.
+
+    The API response is mocked to return:
+      - Clean hourly data up to but NOT including toDateTime (simulating a delayed hourly publish)
+      - Two 6-minute readings just past toDateTime (simulating sub-hourly data that arrived first)
+
+    Expected behavior:
+      - The returned series contains a row at toDateTime
+      - That row's dataValue is the average of the two sub-hourly readings
+      - timeGenerated for that row is close to now (not a historical timestamp)
+    """
+    load_dotenv()
+
+    lighthouse = LIGHTHOUSE()
+
+    # Use a fixed historical window 
+    to_dt = datetime.combine(date(2023, 9, 6), time(12, 0), tzinfo=timezone.utc)
+    from_dt = datetime.combine(date(2023, 9, 6), time(11, 0), tzinfo=timezone.utc)
+
+    seriesDescription = SeriesDescription('LIGHTHOUSE', 'dWaterTmp', 'SouthBirdIsland')
+    timeDescription = TimeDescription(from_dt, to_dt, timedelta(seconds=3600))
+
+    # Build a fake API response:
+    # - One hourly reading at fromDateTime (11:00)
+    # - NO reading at toDateTime (12:00) — simulates delayed hourly publish
+    # - Two 6-minute readings at 12:06 and 12:12 — simulates sub-hourly data that arrived first
+    sub_hourly_val_1 = 22.0
+    sub_hourly_val_2 = 22.6
+    expected_average = (sub_hourly_val_1 + sub_hourly_val_2) / 2
+
+    mock_data = {
+        '013': {
+            'lat': 27.4847,
+            'lon': -97.3181,
+            'data': {
+                'wtp': [
+                    [int(from_dt.timestamp() * 1000), 21.5],                               # 11:00 — clean hourly point
+                    [int((to_dt.timestamp() + 360) * 1000), sub_hourly_val_1],              # 12:06 — sub-hourly
+                    [int((to_dt.timestamp() + 720) * 1000), sub_hourly_val_2],              # 12:12 — sub-hourly
+                ]
+            }
+        }
+    }
+
+    with patch.object(lighthouse, '_LIGHTHOUSE__api_request', return_value=mock_data):
+        result = lighthouse._LIGHTHOUSE__pull_pd_endpoint_dataPoint(seriesDescription, timeDescription)
+
+    assert result is not None, "Expected a series to be returned"
+
+    # Confirm the now-point slot is present
+    result_df = result.dataFrame
+    now_point_rows = result_df[result_df['timeVerified'] == to_dt]
+    assert len(now_point_rows) == 1, (
+        f"Expected exactly one row at toDateTime {to_dt}, found {len(now_point_rows)}"
+    )
+
+    # Confirm the value is the average of the two sub-hourly readings
+    actual_value = float(now_point_rows.iloc[0]['dataValue'])
+    assert abs(actual_value - expected_average) < 0.0001, (
+        f"Expected now-point value {expected_average}, got {actual_value}"
+    )
+
+    # Confirm timeGenerated is recent (within the last minute), not a historical timestamp
+    ingestion_time = now_point_rows.iloc[0]['timeGenerated']
+    age = abs(datetime.now(timezone.utc) - ingestion_time)
+    assert age < timedelta(minutes=1), (
+        f"Expected timeGenerated to be close to now, but was {ingestion_time}"
+    )
+
+    # Confirm the sub-hourly readings themselves did NOT make it into the series
+    past_to_dt = result_df[result_df['timeVerified'] > to_dt]
+    assert len(past_to_dt) == 0, (
+        f"Sub-hourly readings past toDateTime should not appear in the series, found: {past_to_dt}"
     )


### PR DESCRIPTION
## Overrequest Lighthouse Minute Data #920

**What was changed**

85% of Lighthouse failures were on the now-point (the most recent hourly slot) which I'm now questioning becasue of [PR#933](https://github.com/conrad-blucher-institute/semaphore/pull/933)'s discovery but figured I might as well see this through anyway . Lighthouse publishes 6-minute data faster than hourly aggregates, so by the time the model runs there are often already a few sub-hourly readings past the hour that we can use to estimate the missing now-point.

The fix is entirely self-contained in `LIGHTHOUSE.py`. The fetch window is quietly extended 1 hour past `toDateTime` to capture any sub-hourly readings that have come in. If the now-point is missing but at least one sub-hourly reading exists in that window, they're averaged and synthesized as the now-point. The rest of the pipeline sees a complete series and has no idea this happened.

Changes:
- `LIGHTHOUSE.py` — extends `toString` by 1 hour, collects six min readings past `toDateTime` into a separate bucket, and synthesizes the now-point from their average if it's absent
- `test_LIGHTHOUSE.py` — adds `test_now_point_estimated_from_sub_hourly_data` which mocks the API response with a missing now-point and two sub-hourly readings, asserting the synthesized value equals their average and doesn't appear in the series as extra rows

**To Test**

1. `docker compose up --build -d`
2. `docker exec semaphore-core python3 -m pytest src/tests/IntegrationTests/test_LIGHTHOUSE.py`
3. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr -v`


- Note: dspec `range` and `indexes` are unchanged — this fix lives entirely in ingestion as when looking over the lighthouse class I thought this would be simpler but if we hate it I can change it. 