### PR TITLE
deactivated the 6hr crps test model

### DIFF
--- a/data/dspec/CRPS/CRPS_6hr.json
+++ b/data/dspec/CRPS/CRPS_6hr.json
@@ -5,7 +5,7 @@
     "author": "Miranda White",
     "modelFileName": "./CRPS/CRPS_6hr/CRPS_6hr_member*.keras",
     "timingInfo": {
-        "active": true,
+        "active": false,
         "offset": 1200,
         "interval": 3600
     },


### PR DESCRIPTION
 # Why?

We intend to push to prod and do not want a test model running on the server.


# Testing:
 * `docker compose up -d --build     `  
 * `python3 tools/init_cron.py -r ./data/dspec -i ./schedule  `    
 
 
 The terminal should show all CRPS models are false:

<img width="1138" height="215" alt="image" src="https://github.com/user-attachments/assets/de323f49-999c-42db-9bc1-cddd4e23228a" />
