### PR TITLE
fixing indexing for series overrequesting lighthouse

### DIFF
--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float", 
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
@@ -88,16 +88,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
@@ -92,16 +92,16 @@
             "key": "south-bird-island_water-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {
             "key": "south-bird-island_air-temp_25",
             "dType": "float",
             "indexes": [
-                0,
-                25
+                2,
+                27
             ]
         },
         {

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",     "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",     "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25", "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25", "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",     "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",     "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25", "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25", "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F7", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F7", "dType": "float" }
     ]

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F20", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F20", "dType": "float" }
     ]

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -173,14 +173,14 @@
         }
     ],
     "vectorOrder": [
-        { "key": "PL_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "PL_Surge_25",       "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "POC_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [0, 25] },
-        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [0, 25] },
-        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
-        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [0, 25] },
+        { "key": "PL_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "PL_Surge_25",       "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "POC_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_PWL_25",        "dType": "float", "indexes": [2, 27] },
+        { "key": "AVG_Surge_25",      "dType": "float", "indexes": [2, 27] },
+        { "key": "x_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
+        { "key": "y_PL_PWNDCMP_25",  "dType": "float", "indexes": [2, 27] },
         { "key": "x_PL_PWNDCMP_F43", "dType": "float" },
         { "key": "y_PL_PWNDCMP_F43", "dType": "float" }
     ]


### PR DESCRIPTION
### The Bug

Currently for lighthouse models we over request data in the past in order to ensure room for interpolation. There are two tickets in the works to make this process more useful/sustainable 1) to see if we can also over request into the future, and 2) clipping the date range so that we only validate on what the model actually needs, not the entire over requested range.

This error was found while working on these two tickets. In main right now this is the current behavior:

[DEBUG] Series "south-bird-island_air-temp_25" post-validation:
  Reference time: 2026-04-21 16:00:00+00:00
  Shape: (27, 7)
  Expected range: 2026-04-20 14:00:00+00:00 ΓåÆ 2026-04-21 16:00:00+00:00  interval=1:00:00
  Null count: 0 / 27
                timeVerified    offset_from_ref dataValue
0  2026-04-20 14:00:00+00:00  -2 days +22:00:00      21.1
1  2026-04-20 15:00:00+00:00  -2 days +23:00:00      19.5
2  2026-04-20 16:00:00+00:00  -1 days +00:00:00      20.5
3  2026-04-20 17:00:00+00:00  -1 days +01:00:00      20.2
4  2026-04-20 18:00:00+00:00  -1 days +02:00:00      20.2
..                       ...                ...       ...
22 2026-04-21 12:00:00+00:00  -1 days +20:00:00      23.0
23 2026-04-21 13:00:00+00:00  -1 days +21:00:00      22.9
24 2026-04-21 14:00:00+00:00  -1 days +22:00:00      23.6
25 2026-04-21 15:00:00+00:00  -1 days +23:00:00      23.8
26 2026-04-21 16:00:00+00:00    0 days 00:00:00      24.3

This is the data post-validation (has been interpolated and we have the entire date range).

This is the data going into the model after indexing:

[DEBUG] "south-bird-island_air-temp_25" sliced into vector (index [0:25]):
  2026-04-20 14:00:00+00:00  val=21.1
  2026-04-20 15:00:00+00:00  val=19.5
  2026-04-20 16:00:00+00:00  val=20.5
  2026-04-20 17:00:00+00:00  val=20.2
  2026-04-20 18:00:00+00:00  val=20.2
  2026-04-20 19:00:00+00:00  val=20.4
  2026-04-20 20:00:00+00:00  val=20.6
  2026-04-20 21:00:00+00:00  val=21.0
  2026-04-20 22:00:00+00:00  val=21.2
  2026-04-20 23:00:00+00:00  val=20.9
  2026-04-21 00:00:00+00:00  val=22.3
  2026-04-21 01:00:00+00:00  val=21.9
  2026-04-21 02:00:00+00:00  val=22.7
  2026-04-21 03:00:00+00:00  val=22.7
  2026-04-21 04:00:00+00:00  val=22.7
  2026-04-21 05:00:00+00:00  val=22.9
  2026-04-21 06:00:00+00:00  val=22.9
  2026-04-21 07:00:00+00:00  val=22.8
  2026-04-21 08:00:00+00:00  val=22.8
  2026-04-21 09:00:00+00:00  val=23.0
  2026-04-21 10:00:00+00:00  val=22.4
  2026-04-21 11:00:00+00:00  val=22.7
  2026-04-21 12:00:00+00:00  val=23.0
  2026-04-21 13:00:00+00:00  val=22.9
  2026-04-21 14:00:00+00:00  val=23.6
04/21/26 16:25:05: 		south-bird-island_air-temp_25: - amnt_found: 27, indexed_len: 25

The issue here is that rather than getting ride of the over requested values in the past, our current indexing on the series [0, 25] clips off the now time and the last our of measurements.

This is not the behavior we want as the models should be ingesting the past 24 hours of air temperature measurements and the now point. I thought it would be better to make this a separate bug fix issue before tackling the other two tickets.

This is critical as this means that as of this moment, both semaphore dev and prod are going feeding the cold stunning models the wrong data.


### The Fix

Indexing correctly on [2, 27] rather than [0, 25], results below. 

```
[DEBUG] Series "south-bird-island_air-temp_25" post-validation:
  Reference time: 2026-04-21 16:00:00+00:00
  Shape: (27, 7)
  Expected range: 2026-04-20 14:00:00+00:00 ΓåÆ 2026-04-21 16:00:00+00:00  interval=1:00:00
  Null count: 0 / 27
                timeVerified    offset_from_ref dataValue
0  2026-04-20 14:00:00+00:00  -2 days +22:00:00      21.1
1  2026-04-20 15:00:00+00:00  -2 days +23:00:00      19.5
2  2026-04-20 16:00:00+00:00  -1 days +00:00:00      20.5
3  2026-04-20 17:00:00+00:00  -1 days +01:00:00      20.2
4  2026-04-20 18:00:00+00:00  -1 days +02:00:00      20.2
..                       ...                ...       ...
22 2026-04-21 12:00:00+00:00  -1 days +20:00:00      23.0
23 2026-04-21 13:00:00+00:00  -1 days +21:00:00      22.9
24 2026-04-21 14:00:00+00:00  -1 days +22:00:00      23.6
25 2026-04-21 15:00:00+00:00  -1 days +23:00:00      23.8
26 2026-04-21 16:00:00+00:00    0 days 00:00:00      24.3
```

```
[DEBUG] "south-bird-island_air-temp_25" sliced into vector (index [2:27]):
  2026-04-20 16:00:00+00:00  val=20.5
  2026-04-20 17:00:00+00:00  val=20.2
  2026-04-20 18:00:00+00:00  val=20.2
  2026-04-20 19:00:00+00:00  val=20.4
  2026-04-20 20:00:00+00:00  val=20.6
  2026-04-20 21:00:00+00:00  val=21.0
  2026-04-20 22:00:00+00:00  val=21.2
  2026-04-20 23:00:00+00:00  val=20.9
  2026-04-21 00:00:00+00:00  val=22.3
  2026-04-21 01:00:00+00:00  val=21.9
  2026-04-21 02:00:00+00:00  val=22.7
  2026-04-21 03:00:00+00:00  val=22.7
  2026-04-21 04:00:00+00:00  val=22.7
  2026-04-21 05:00:00+00:00  val=22.9
  2026-04-21 06:00:00+00:00  val=22.9
  2026-04-21 07:00:00+00:00  val=22.8
  2026-04-21 08:00:00+00:00  val=22.8
  2026-04-21 09:00:00+00:00  val=23.0
  2026-04-21 10:00:00+00:00  val=22.4
  2026-04-21 11:00:00+00:00  val=22.7
  2026-04-21 12:00:00+00:00  val=23.0
  2026-04-21 13:00:00+00:00  val=22.9
  2026-04-21 14:00:00+00:00  val=23.6
  2026-04-21 15:00:00+00:00  val=23.8
  2026-04-21 16:00:00+00:00  val=24.3
04/21/26 16:52:44: 		south-bird-island_air-temp_25: - amnt_found: 27, indexed_len: 25
```