### PR TITLE
919 lighthouse haunted data gap fix electric boogaloo

### DIFF
--- a/src/DataValidation/DataValidationClasses/DateRangeValidation.py
+++ b/src/DataValidation/DataValidationClasses/DateRangeValidation.py
@@ -25,12 +25,11 @@ class DateRangeValidation(IDataValidation):
         self.referenceTime = referenceTime
         
     def validate(self, series: Series) -> bool:
-        """ This method checks for missing date ranges in the the expected time series. 
+        """ This method checks for missing data points in the the expected time series. 
             :param series: Series - The series to validate
             :return: bool - True if the series passes validation, False otherwise
         """
-
-        if series.dataFrame is None or len(series.dataFrame) <= 0:
+        if series.dataFrame is None or series.dataFrame.empty:
             log_error('DateRangeValidation: No data in series to validate.')
             return False # No data to validate
     
@@ -64,6 +63,7 @@ class DateRangeValidation(IDataValidation):
             if time_difference > series.timeDescription.stalenessOffset:
                 log_error(f'DateRangeValidation: Series {series} is stale.')
                 log_error(f'Time difference: {time_difference}. Staleness offset: {series.timeDescription.stalenessOffset}')
+                log_error(f'Min timeGenerated: {series.dataFrame["timeGenerated"].min()}')
                 return False
         
         return True

--- a/src/ModelExecution/InputVectorBuilder.py
+++ b/src/ModelExecution/InputVectorBuilder.py
@@ -121,6 +121,15 @@ class InputVectorBuilder:
 
                     # Select only the wanted data
                     indexed_data = casted_data[index[0] : index[1]]
+
+                    # --- DEBUG ---
+                    if batchIndex == 0:
+                        timestamps = series.dataFrame['timeVerified'].tolist()
+                        sliced_ts = timestamps[index[0] : index[1]]
+                        print(f'\n[DEBUG] "{key}" sliced into vector (index [{index[0]}:{index[1]}]):')
+                        for ts, val in zip(sliced_ts, indexed_data):
+                            print(f'  {ts}  val={val}')
+                    # --- END DEBUG ---
                     
                     log(f'\t\t{key}: - amnt_found: {len(casted_data)}, indexed_len: {len(indexed_data)}')
                     # Concatenate the designated slice of casted data into the input vector

--- a/src/ModelExecution/InputVectorBuilder.py
+++ b/src/ModelExecution/InputVectorBuilder.py
@@ -121,15 +121,6 @@ class InputVectorBuilder:
 
                     # Select only the wanted data
                     indexed_data = casted_data[index[0] : index[1]]
-
-                    # --- DEBUG ---
-                    if batchIndex == 0:
-                        timestamps = series.dataFrame['timeVerified'].tolist()
-                        sliced_ts = timestamps[index[0] : index[1]]
-                        print(f'\n[DEBUG] "{key}" sliced into vector (index [{index[0]}:{index[1]}]):')
-                        for ts, val in zip(sliced_ts, indexed_data):
-                            print(f'  {ts}  val={val}')
-                    # --- END DEBUG ---
                     
                     log(f'\t\t{key}: - amnt_found: {len(casted_data)}, indexed_len: {len(indexed_data)}')
                     # Concatenate the designated slice of casted data into the input vector

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -24,7 +24,7 @@ from DataValidation.IDataValidation import data_validation_factory
 from exceptions import Semaphore_Data_Exception, Semaphore_Ingestion_Exception
 from datetime import datetime, timedelta
 from pandas import date_range
-
+import copy
 
 
 class DataGatherer:
@@ -83,6 +83,8 @@ class DataGatherer:
 
         :param dependentSeriesList: list[DependentSeries] - The list of dependent series from the DSEPC
         :param referenceTime: datetime - The reference time to build the time description from.
+        :param key_to_index: dict[str, list[int]] - A mapping of outKey to vectorOrder index slice,
+            used to clip the series before validation so buffer slots are not validated.
 
         :returns: dict[str, Series] - The dictionary of the data it collected 
 
@@ -123,25 +125,11 @@ class DataGatherer:
             # Reset the index
             series.dataFrame.reset_index(inplace=True)
 
-            # Before validation, trim to only the rows the model will actually consume
-            index = key_to_index.get(key)
-            if index is not None:
-                trimmed_df = series.dataFrame.iloc[index[0]:index[1]].reset_index(drop=True)
-                trimmed_from = trimmed_df['timeVerified'].iloc[0]
-                trimmed_to = trimmed_df['timeVerified'].iloc[-1]
-                trimmed_td = TimeDescription(
-                    trimmed_from,
-                    trimmed_to,
-                    series.timeDescription.interval,
-                    series.timeDescription.stalenessOffset
-                )
-                series_for_validation = Series.__new__(Series)
-                series_for_validation.__dict__.update(series.__dict__)
-                series_for_validation.dataFrame = trimmed_df
-                series_for_validation.timeDescription = trimmed_td
-                self.__validate_series(series_for_validation, referenceTime)
-            else:
-                self.__validate_series(series, referenceTime)
+            # Validate only the rows the model will actually consume, not the full
+            # over-requested window including interpolation buffer slots.
+            # The full series (all rows) still goes into the repository so vectorOrder
+            # can index it normally downstream.
+            self.__clip_and_validate_series(series, key, key_to_index, referenceTime)
             
             # Full Series (all 27 rows including buffer) still goes in the repo
             series_repository[key] = series
@@ -149,6 +137,52 @@ class DataGatherer:
         return series_repository
 
 
+    def __clip_and_validate_series(self, series: Series, key: str, key_to_index: dict[str, list[int]], referenceTime: datetime):
+        """Clips the series to the rows the model will actually consume according to
+        the vectorOrder index, then validates the clipped series. This prevents
+        interpolation buffer slots (over-requested rows that exist only to support
+        interpolation at the boundaries) from causing false-positive validation failures.
+
+        If no index is found for the key (e.g. the key is only used in post-processing
+        and not directly in vectorOrder), the full series is validated as-is.
+
+        :param series: Series - The full series to clip and validate
+        :param key: str - The outKey for this series, used to look up the vectorOrder index
+        :param key_to_index: dict[str, list[int]] - Mapping of outKey to vectorOrder [start, end] slice
+        :param referenceTime: datetime - The reference time for this model
+        """
+        index = key_to_index.get(key)
+
+        if index is not None:
+            # Slice the dataframe to only the rows vectorOrder will read.
+            # This is the same slice InputVectorBuilder applies — validation should
+            # only check what the model actually consumes.
+            trimmed_df = series.dataFrame.iloc[index[0]:index[1]].reset_index(drop=True)
+
+            # Build a corrected TimeDescription whose fromDateTime and toDateTime
+            # match the actual first and last rows of the trimmed slice. DateRangeValidation
+            # uses these to construct its expected index — if they still pointed at the
+            # full over-requested window, validation would flag the trimmed rows as missing.
+            trimmed_td = TimeDescription(
+                trimmed_df['timeVerified'].iloc[0],
+                trimmed_df['timeVerified'].iloc[-1],
+                series.timeDescription.interval,
+                series.timeDescription.stalenessOffset
+            )
+
+            # Shallow copy so we can swap dataFrame and timeDescription without
+            # mutating the original series that will be stored in the repository.
+            # A shallow copy is sufficient here — we only need to replace two attributes,
+            # and DateRangeValidation makes its own internal copy before operating.
+            series_for_validation = copy.copy(series)
+            series_for_validation.dataFrame = trimmed_df
+            series_for_validation.timeDescription = trimmed_td
+
+            self.__validate_series(series_for_validation, referenceTime)
+        else:
+            self.__validate_series(series, referenceTime)
+
+    
     def __post_process_data(self, series_repository: dict[str, Series], postProcessCalls: list[PostProcessCall]) -> dict[str, Series]:
         """
         This function calls the post processing methods for any inputs that need post processing.

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -100,6 +100,17 @@ class DataGatherer:
             # Request the data from Series provider from its description 
             series = self.__seriesProvider.request_input(seriesDescription, timeDescription, referenceTime)
 
+            # --- DEBUG: raw from DB before integrity ---
+            print(f'\n[DEBUG] Series "{key}" raw from DB (pre-integrity):')
+            print(f'  Reference time: {referenceTime}')
+            print(f'  Row count: {len(series.dataFrame)}')
+            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
+            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
+                lambda t: str(t - referenceTime) if hasattr(t, 'tzinfo') else str(t - referenceTime.replace(tzinfo=None))
+            )
+            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
+# --- END DEBUG ---
+
             # Perform data integrity processing if specified
             if dependentSeries.dataIntegrityCall is not None:
                 # Create an instance of the data integrity class and execute it
@@ -119,8 +130,34 @@ class DataGatherer:
             # Reset the index
             series.dataFrame.reset_index(inplace=True)
 
+            # --- DEBUG: show actual data going into validation ---
+            print(f'\n[DEBUG] Series "{key}" post-reindex (pre-validation):')
+            print(f'  Reference time: {referenceTime}')
+            print(f'  Shape: {series.dataFrame.shape}')
+            print(f'  Expected range: {series.timeDescription.fromDateTime} → {series.timeDescription.toDateTime}  interval={series.timeDescription.interval}')
+            print(f'  Null count: {series.dataFrame["dataValue"].isnull().sum()} / {len(series.dataFrame)}')
+            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
+            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
+                lambda t: str(t - referenceTime) if t is not None and not df_display['timeVerified'].isnull().all() else 'NaT'
+            )
+            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
+            # --- END DEBUG ---
+
             # Validate the data
             self.__validate_series(series, referenceTime)
+
+            # --- DEBUG: show actual data going into model ---
+            print(f'\n[DEBUG] Series "{key}" post-validation:')
+            print(f'  Reference time: {referenceTime}')
+            print(f'  Shape: {series.dataFrame.shape}')
+            print(f'  Expected range: {series.timeDescription.fromDateTime} → {series.timeDescription.toDateTime}  interval={series.timeDescription.interval}')
+            print(f'  Null count: {series.dataFrame["dataValue"].isnull().sum()} / {len(series.dataFrame)}')
+            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
+            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
+                lambda t: str(t - referenceTime) if t is not None and not df_display['timeVerified'].isnull().all() else 'NaT'
+            )
+            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
+            # --- END DEBUG ---
             
             # Store the series in the repository
             series_repository[key] = series

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -56,8 +56,12 @@ class DataGatherer:
         dependentSeries: list[DependentSeries] = dspec.dependentSeries
         postProcessCalls: list[PostProcessCall] = dspec.postProcessCall
 
+        # Build a dict of {key: index} so validation knows the actual consumed window
+        vector_order = dspec.orderedVector
+        key_to_index = dict(zip(vector_order.keys, vector_order.indexes))
+        
         # Get Dependent Data
-        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime)
+        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime, key_to_index)
 
         # Call post processing 
         post_processed_series_repository = self.__post_process_data(dependent_data_repository, postProcessCalls)
@@ -65,7 +69,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime) -> dict[str, Series]:
+    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]]) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description
@@ -100,17 +104,6 @@ class DataGatherer:
             # Request the data from Series provider from its description 
             series = self.__seriesProvider.request_input(seriesDescription, timeDescription, referenceTime)
 
-            # --- DEBUG: raw from DB before integrity ---
-            print(f'\n[DEBUG] Series "{key}" raw from DB (pre-integrity):')
-            print(f'  Reference time: {referenceTime}')
-            print(f'  Row count: {len(series.dataFrame)}')
-            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
-            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
-                lambda t: str(t - referenceTime) if hasattr(t, 'tzinfo') else str(t - referenceTime.replace(tzinfo=None))
-            )
-            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
-# --- END DEBUG ---
-
             # Perform data integrity processing if specified
             if dependentSeries.dataIntegrityCall is not None:
                 # Create an instance of the data integrity class and execute it
@@ -130,36 +123,27 @@ class DataGatherer:
             # Reset the index
             series.dataFrame.reset_index(inplace=True)
 
-            # --- DEBUG: show actual data going into validation ---
-            print(f'\n[DEBUG] Series "{key}" post-reindex (pre-validation):')
-            print(f'  Reference time: {referenceTime}')
-            print(f'  Shape: {series.dataFrame.shape}')
-            print(f'  Expected range: {series.timeDescription.fromDateTime} → {series.timeDescription.toDateTime}  interval={series.timeDescription.interval}')
-            print(f'  Null count: {series.dataFrame["dataValue"].isnull().sum()} / {len(series.dataFrame)}')
-            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
-            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
-                lambda t: str(t - referenceTime) if t is not None and not df_display['timeVerified'].isnull().all() else 'NaT'
-            )
-            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
-            # --- END DEBUG ---
-
-            # Validate the data
-            self.__validate_series(series, referenceTime)
-
-            # --- DEBUG: show actual data going into model ---
-            print(f'\n[DEBUG] Series "{key}" post-validation:')
-            print(f'  Reference time: {referenceTime}')
-            print(f'  Shape: {series.dataFrame.shape}')
-            print(f'  Expected range: {series.timeDescription.fromDateTime} → {series.timeDescription.toDateTime}  interval={series.timeDescription.interval}')
-            print(f'  Null count: {series.dataFrame["dataValue"].isnull().sum()} / {len(series.dataFrame)}')
-            df_display = series.dataFrame[['timeVerified', 'dataValue']].copy()
-            df_display['offset_from_ref'] = df_display['timeVerified'].apply(
-                lambda t: str(t - referenceTime) if t is not None and not df_display['timeVerified'].isnull().all() else 'NaT'
-            )
-            print(df_display[['timeVerified', 'offset_from_ref', 'dataValue']].to_string(max_rows=10))
-            # --- END DEBUG ---
+            # Before validation, trim to only the rows the model will actually consume
+            index = key_to_index.get(key)
+            if index is not None:
+                trimmed_df = series.dataFrame.iloc[index[0]:index[1]].reset_index(drop=True)
+                trimmed_from = trimmed_df['timeVerified'].iloc[0]
+                trimmed_to = trimmed_df['timeVerified'].iloc[-1]
+                trimmed_td = TimeDescription(
+                    trimmed_from,
+                    trimmed_to,
+                    series.timeDescription.interval,
+                    series.timeDescription.stalenessOffset
+                )
+                series_for_validation = Series.__new__(Series)
+                series_for_validation.__dict__.update(series.__dict__)
+                series_for_validation.dataFrame = trimmed_df
+                series_for_validation.timeDescription = trimmed_td
+                self.__validate_series(series_for_validation, referenceTime)
+            else:
+                self.__validate_series(series, referenceTime)
             
-            # Store the series in the repository
+            # Full Series (all 27 rows including buffer) still goes in the repo
             series_repository[key] = series
 
         return series_repository

--- a/src/tests/UnitTests/test_dataGatherer.py
+++ b/src/tests/UnitTests/test_dataGatherer.py
@@ -23,7 +23,7 @@ import copy
 from numpy import nan
 from unittest.mock import MagicMock, patch
 from src.ModelExecution.dataGatherer import DataGatherer
-from src.ModelExecution.dspecParser import Dspec, DependentSeries, PostProcessCall
+from src.ModelExecution.dspecParser import Dspec, DependentSeries, PostProcessCall, VectorOrder
 from src.DataClasses import Series, SeriesDescription, TimeDescription, DataIntegrityDescription
 
 ## Mocks
@@ -82,6 +82,11 @@ def mock_dspec():
     dspec.postProcessCall = [
             postProcessCall
         ]
+
+    mock_vector_order = MagicMock()
+    mock_vector_order.keys = ['key1']
+    mock_vector_order.indexes = [[0, 2]]  # matches the 2-row dataframe used in tests
+    dspec.orderedVector = mock_vector_order
 
     return dspec
 
@@ -316,3 +321,62 @@ def test_data_validation_call(data_gatherer):
 
         # Assert that the returned object's .validate method was called
         mock_validator.validate.assert_called_once_with(mock_series)
+
+def test_buffer_slots_trimmed_before_validation(data_gatherer, mock_dspec):
+    """Asserts that only the rows specified by vectorOrder indexes are validated,
+    not the full series including interpolation buffer slots.
+    
+    The fix being tested: DataGatherer now clips the series to the vectorOrder
+    index window before running DateRangeValidation, so null buffer slots at the
+    end of the series (which exist only to support interpolation) don't cause
+    false-positive validation failures.
+    """
+    reference_time = datetime.now(timezone.utc)
+
+    # Build a time description spanning 5 hours to match the 5-row dataframe below
+    mock_timeDescription = MagicMock(spec=TimeDescription)
+    mock_timeDescription.configure_mock(
+        fromDateTime=reference_time,
+        toDateTime=reference_time + timedelta(hours=4),
+        interval=timedelta(hours=1),
+        stalenessOffset=timedelta(hours=7)
+    )
+
+    # No verification override so DateRangeValidation will be used
+    mock_description = MagicMock(spec=SeriesDescription)
+    mock_description.configure_mock(verificationOverride=None)
+
+    mock_series = MagicMock(spec=Series)
+    mock_series.configure_mock(description=mock_description, timeDescription=mock_timeDescription)
+
+    # 5 rows total: the first 3 are real data the model will consume,
+    # the last 2 are null buffer slots that exist only so interpolation
+    # has boundary points to work with. Without the fix, DateRangeValidation
+    # would see these nulls and fail the whole model run.
+    mock_series.configure_mock(dataFrame=DataFrame({
+        'dataValue': [1.0, 2.0, 3.0, None, None],
+        'timeVerified': [
+            reference_time,
+            reference_time + timedelta(hours=1),
+            reference_time + timedelta(hours=2),
+            reference_time + timedelta(hours=3),  # buffer slot
+            reference_time + timedelta(hours=4),  # buffer slot
+        ],
+        'timeGenerated': [reference_time] * 5
+    }))
+
+    # Override the mock_dspec's vectorOrder to only consume the first 3 rows,
+    # leaving the 2 null buffer slots outside the index window
+    mock_vector_order = MagicMock()
+    mock_vector_order.keys = ['key1']
+    mock_vector_order.indexes = [[0, 3]]
+    mock_dspec.orderedVector = mock_vector_order
+
+    # Return our 5-row series (including null buffer slots) from the series provider
+    data_gatherer._DataGatherer__seriesProvider.request_input.return_value = mock_series
+
+    # Should succeed: validation only runs against rows 0-2 (the 3 real data points).
+    # If the fix is broken and validation runs against all 5 rows, the nulls at
+    # index 3 and 4 will cause DateRangeValidation to fail and raise an exception.
+    result = data_gatherer.get_data_repository(mock_dspec, reference_time)
+    assert 'key1' in result


### PR DESCRIPTION
### Interior Haunted Gap Failures

One dropout from lighthouse produced exactly two failure batches. The issue is that the model over requests data, but doesn’t actually need the over requested points. The vectorOrder only indexes the needed, data points, however date range validation runs before vectorOrder does.  But DateRangeValidation validates the entire requested window including the buffer slot. 

DataGatherer validates all 27 slots but the model only ever reads 26 slots. DateRangeValidation doesn't know extra slots are a buffer it's allowed to ignore.

## Current Behavior

DataGatherer requests the input, pulling from the db or data ingestion. Next, data integrity processes are called (this is interpolation, we don't have any integrity classes that aren't interpolation). After interpolation we set the index to time verified and reindex the series to the interval used in the model. Finally the data is validated and then stored in the series_repository where it will later go through post processing and vector ordering before being passed to the model. 

The point of contention here is validation, we need to ensure only the data necessary for the model to run is being validated. 

## Fix

Pass only the indexed data to validation. I made some changes based on feedback from Mrs. Tissot on the previous PR, rather than the clipping being done inside of data validation, we do the clipping outside and then pass the clipped series to data validation. Things should be a written a bit more explicitly as well. I thought about Matthew's idea of having this it's own class but I think that might be overkill for what is ultimately a temporary shift just so that data validation looks at the right points. (If someone would add copilot I would appreciate it.)

**To Test**

1. `docker compose up --build -d`
2. `docker exec semaphore-core python3 -m pytest`
3. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr -v`
