### PR TITLE
Fixing retracing warning

### DIFF
--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -94,8 +94,7 @@ class ModelRunner:
         If performance becomes an issue, we may need to implement our own batching. Because our datasets are generally kbs in size, this should not be a problem. 
         The batching overhead costs more than we would save.
         """
-        input_dtype = models[0].input.dtype
-        input_tensor = tf.constant(shapedInputs, dtype=input_dtype)
+        input_tensor = tf.constant(shapedInputs)
         predictions = [model(input_tensor, training=False).numpy() for model in models]
         return np.stack(predictions, axis=0)
 

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -19,7 +19,7 @@ from exceptions import Semaphore_Exception
 from ModelExecution.dspecParser import Dspec
 import re
 import datetime
-from os import path, getenv
+from os import getenv
 from numpy import reshape
 import numpy as np
 import glob
@@ -94,7 +94,8 @@ class ModelRunner:
         If performance becomes an issue, we may need to implement our own batching. Because our datasets are generally kbs in size, this should not be a problem. 
         The batching overhead costs more than we would save.
         """
-        input_tensor = tf.constant(shapedInputs, dtype=tf.float32)
+        input_dtype = models[0].input.dtype
+        input_tensor = tf.constant(shapedInputs, dtype=input_dtype)
         predictions = [model(input_tensor, training=False).numpy() for model in models]
         return np.stack(predictions, axis=0)
 

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -89,10 +89,10 @@ class ModelRunner:
             :param shapedInputs: np.ndarray - The input data reshaped to match the model's expected input shape.
             :returns np.ndarray - A 3D array containing predictions from all models, stacked along a new axis.
         
-        This function prefers the lower level model(x, training=False) call instead of model.predict(). This avoids
-        retracing and recompiling overhead for normal TensorFlow execution. For compatibility with existing tests and
-        mocks that still provide only model.predict(), we fall back to model.predict() when a direct call is not
-        available or does not return a tensor-like object with .numpy().
+        This function properly calls the lower level model(x, training=False) instead of model.predict(). This is to avoid retracing and recompiling the model.
+        However, this means that we have no batching, dataset conversions, or other optimizations that come with using model.predict(). 
+        If performance becomes an issue, we may need to implement our own batching. Because our datasets are generally kbs in size, this should not be a problem. 
+        The batching overhead costs more than we would save.
         """
         input_dtype = models[0].input.dtype
         input_tensor = tf.constant(shapedInputs, dtype=input_dtype)

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -89,13 +89,25 @@ class ModelRunner:
             :param shapedInputs: np.ndarray - The input data reshaped to match the model's expected input shape.
             :returns np.ndarray - A 3D array containing predictions from all models, stacked along a new axis.
         
-        This function properly calls the lower level model(x, training=False) instead of model.predict(). This is to avoid retracing and recompiling the model.
-        However, this means that we have no batching, dataset conversions, or other optimizations that come with using model.predict(). 
-        If performance becomes an issue, we may need to implement our own batching. Because our datasets are generally kbs in size, this should not be a problem. 
-        The batching overhead costs more than we would save.
+        This function prefers the lower level model(x, training=False) call instead of model.predict(). This avoids
+        retracing and recompiling overhead for normal TensorFlow execution. For compatibility with existing tests and
+        mocks that still provide only model.predict(), we fall back to model.predict() when a direct call is not
+        available or does not return a tensor-like object with .numpy().
         """
         input_tensor = tf.constant(shapedInputs, dtype=tf.float32)
-        predictions = [model(input_tensor, training=False).numpy() for model in models]
+        predictions = []
+
+        for model in models:
+            try:
+                prediction = model(input_tensor, training=False)
+                if hasattr(prediction, "numpy"):
+                    prediction = prediction.numpy()
+                else:
+                    prediction = model.predict(shapedInputs)
+            except (TypeError, AttributeError):
+                prediction = model.predict(shapedInputs)
+
+            predictions.append(prediction)
         return np.stack(predictions, axis=0)
 
     def __load_models(self, DSPEC: Dspec) -> list[Model]:

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -23,8 +23,8 @@ from os import path, getenv
 from numpy import reshape
 import numpy as np
 import glob
+import tensorflow as tf
 from tensorflow.keras.models import load_model, Model
-
 
 class ModelRunner:
 
@@ -60,15 +60,7 @@ class ModelRunner:
         shapedInputs = reshape(input_vectors, expectedShape)
 
         log('Init compute predictions for all models....')
-
-        all_predictions = []
-
-        for model in models:
-            prediction = model.predict(shapedInputs)
-            all_predictions.append(prediction)
-
-        # Stack predictions → shape becomes (models, input_vectors, outputs)
-        stacked_predictions = np.stack(all_predictions, axis=0)
+        stacked_predictions: np.ndarray = self.predict(models, shapedInputs)
 
         log('Init prediction post process....')
 
@@ -89,12 +81,27 @@ class ModelRunner:
 
         series.dataFrame = processedOutputs
         return series
-    
+
+    def predict(self, models: list[Model], shapedInputs: np.ndarray) -> np.ndarray:
+        """
+        This function runs predictions for each model using the same input data and stacks the results.
+            :param models: list[Model] - A list of loaded TensorFlow models to run predictions with.
+            :param shapedInputs: np.ndarray - The input data reshaped to match the model's expected input shape.
+            :returns np.ndarray - A 3D array containing predictions from all models, stacked along a new axis.
+        
+        This function properly calls the lower level model(x, training=False) instead of model.predict(). This is to avoid retracing and recompiling the model.
+        However, this means that we have no batching, dataset conversions, or other optimizations that come with using model.predict(). 
+        If performance becomes an issue, we may need to implement our own batching. Because our datasets are generally kbs in size, this should not be a problem. 
+        The batching overhead costs more than we would save.
+        """
+        input_tensor = tf.constant(shapedInputs, dtype=tf.float32)
+        predictions = [model(input_tensor, training=False).numpy() for model in models]
+        return np.stack(predictions, axis=0)
 
     def __load_models(self, DSPEC: Dspec) -> list[Model]:
         """
         This function will construct the model path based on the dspec and will 
-        to load all models that match the path.
+        load all models that match the path.
 
         :param DSPEC: Dspec - The Dspec file with the model loading information
 

--- a/src/ModelExecution/modelRunner.py
+++ b/src/ModelExecution/modelRunner.py
@@ -60,7 +60,7 @@ class ModelRunner:
         shapedInputs = reshape(input_vectors, expectedShape)
 
         log('Init compute predictions for all models....')
-        stacked_predictions: np.ndarray = self.predict(models, shapedInputs)
+        stacked_predictions: np.ndarray = self.__predict(models, shapedInputs)
 
         log('Init prediction post process....')
 
@@ -82,7 +82,7 @@ class ModelRunner:
         series.dataFrame = processedOutputs
         return series
 
-    def predict(self, models: list[Model], shapedInputs: np.ndarray) -> np.ndarray:
+    def __predict(self, models: list[Model], shapedInputs: np.ndarray) -> np.ndarray:
         """
         This function runs predictions for each model using the same input data and stacks the results.
             :param models: list[Model] - A list of loaded TensorFlow models to run predictions with.

--- a/src/tests/UnitTests/test_modelRunner.py
+++ b/src/tests/UnitTests/test_modelRunner.py
@@ -19,7 +19,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 import numpy as np
 from numpy import float32
-
+import tensorflow as tf
 from src.ModelExecution.modelRunner import ModelRunner
 from src.ModelExecution.dspecParser import Dspec, OutputInfo, ExpectedOutputShape
 from src.DataClasses import Series, SemaphoreSeriesDescription
@@ -66,15 +66,19 @@ def mock_models_with_order(num_models, num_outputs=5):
     for i in range(num_models):
         mock_model = MagicMock()
         mock_model.input_shape = (None, 87)
+        mock_model.input.dtype = tf.float32 
 
         def make_predict(val):
-            def predict(inputs):
-                batch_size = len(inputs)
+            def predict(inputs, training=False):
+                batch_size = int(inputs.shape[0])
                 row = [val + j for j in range(num_outputs)]
-                return np.array([row] * batch_size, dtype=float32)
+                arr = np.array([row] * batch_size, dtype=float32)
+                result = MagicMock()
+                result.numpy.return_value = arr
+                return result
             return predict
 
-        mock_model.predict.side_effect = make_predict(i + 1)
+        mock_model.side_effect = make_predict(i + 1)
         models.append(mock_model)
 
     return models


### PR DESCRIPTION
## What is this?
When running the crps models between executions we were getting a warning from TensorFlow.  This PR fixes the core cause of these warnings


```
21ms/stepWARNING:tensorflow:6 out of the last 12 calls to <function TensorFlowTrainer.make_predict_function.<locals>.one_step_on_data_distributed at 0x7c389bde3100> 
triggered tf.function retracing. Tracing is expensive and the excessive number of tracings could be due 
to (1) creating @tf.function repeatedly in a loop, (2) passing tensors with different shapes, (3) passing 
Python objects instead of tensors. For (1), please define your @tf.function outside of the loop. For (2), 
@tf.function has reduce_retracing=True option that can avoid unnecessary retracing. For (3), please 
refer to https://www.tensorflow.org/guide/function#controlling_retracing and https://www.tensorflow.org/api_docs/python/tf/function for  more details.
```



## Why the warning?

### Tracing
The first thing to understand is what is tracing. TensorFlow is optimized to run a single model a lot of times. One of these optimizations is called tracing. Basically it runs your model once and records what operations occurred. From that record it produces something called a [graph](https://www.tensorflow.org/guide/intro_to_graphs). This graph can then be optimized and cached, it will be converted to the c++ execution and will be used on the next times your model is executed. The overhead of tracing pays of with really large models during extremely long training loops.

### Why are we being told we are retracing? 
Each time we call predict with a new model, the internal state of TensorFlow is told to trace this new model. It doesn't assume that the plan it has is still valid, more than that there isn't a way afaik to tell it that its plan is still valid. There are a lot of proper bugs that could cause many retraces to occur, such as non-uniform data size, incorrect batching, or other things. If I was a ML engineer I would want to know about this before it 10xs my training time.

### How do we fix it?
The fix as best I can tell is to just not let it trace at all. There isn't a kill flag afaik. There is a `@tf.function(reduce_retracing=true)` decorator, but trust me that bring more problems than it fixes and It didn't even work for me. The fix is switching from (`model.predict(X)` -> `model(x, training=false)`, switching from optimization to eager execution.

### What is the difference between the two?
```python3
model.predict(X)
```
This is a higher level function to interact with TF. It handles more tasks than just running a model. (eg. Batching, dataset conversion, other preprocessing tasks). Then it does the forward pass*. And yes, part of its optimization is triggering tracing to occur.

```python3
model(x, training=false)
``` 

This is a lower level function to interact with TF. It is just a forwards pass*. The upside is we dont trigger tracing. The downside is we lose some of the sausage making that tf was doing for us, mainly converting our tensorlike data structure (ndarray) to a tensor for us, and returning back to us an ndarray. 

*Forward pass is a closer to ML terminology for running input data through weights. The name for the forward run through the model. During training we capture gradients and compute loss through something called the backward pass. If you use PyTorch or define a costume model you interact with the forward and backward methods a lot. TF treats the `Model` like a function and thus executing the function calls forward.

### Conclusion
All and all this PR is really to remove this warning from occurring and to give the comfort that we are using our tools properly and with intention. With the kbs of data we are moving around the time save from not retracing is almost nothing. I actually found out we can parallelize our models runs, but I stopped myself because the overhead of that optimization might actually make us lose time even though its cool. Its the same thing with batching. Yes we would have to implement batching ourselves if we need it, but its just so far from needed with our data size. Importantly tracing DOES NOT HELP US. Because we execute as a single batch of all our data through a model, the eager execution is better for us because we do all of our computation in one pass through the model. 

## Test
1. Build and run
```bash
docker compose up --build -d
```

2. Run a .h5 file model
```bash
docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json -v
```

3. Run a .keras model
```bash
docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/CRPS/CRPS_6hr.json -v
```
