### PR TITLE
ADDITIONAL HOUR INTO FUTURE

### DIFF
--- a/data/dspec/CRPS/CRPS_108hr.json
+++ b/data/dspec/CRPS/CRPS_108hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_120hr.json
+++ b/data/dspec/CRPS/CRPS_120hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_12hr.json
+++ b/data/dspec/CRPS/CRPS_12hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_18hr.json
+++ b/data/dspec/CRPS/CRPS_18hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_24hr.json
+++ b/data/dspec/CRPS/CRPS_24hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_36hr.json
+++ b/data/dspec/CRPS/CRPS_36hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_48hr.json
+++ b/data/dspec/CRPS/CRPS_48hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_60hr.json
+++ b/data/dspec/CRPS/CRPS_60hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_6hr.json
+++ b/data/dspec/CRPS/CRPS_6hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_72hr.json
+++ b/data/dspec/CRPS/CRPS_72hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_84hr.json
+++ b/data/dspec/CRPS/CRPS_84hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/CRPS/CRPS_96hr.json
+++ b/data/dspec/CRPS/CRPS_96hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
@@ -25,7 +25,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -46,7 +46,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_108hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_114hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_12hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_18hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_24hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_30hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_36hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_42hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_48hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_54hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_60hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_66hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_6hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_72hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_78hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_84hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_90hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_96hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",

--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -25,7 +25,7 @@
             "series": "dWaterTmp",
             "unit": "celsius",
             "interval": 3600,
-            "range": [0, -23],
+            "range": [1, -23],
             "outKey": "NPSBI_DWT_24"
         },
         { 
@@ -35,7 +35,7 @@
             "series": "dAirTmp",
             "unit": "celsius",
             "interval": 3600,
-            "range": [0, -23],
+            "range": [1, -23],
             "outKey": "PACK_DAT_24"
         },
         { 

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -25,7 +25,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -39,7 +39,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -54,7 +54,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -68,7 +68,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -82,7 +82,7 @@
             "series": "dWnDir",
             "unit": "degrees",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNDIR_25",
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
@@ -96,7 +96,7 @@
             "series": "dWnSpd",
             "unit": "mps",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNSPD_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -25,7 +25,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -39,7 +39,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -54,7 +54,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -68,7 +68,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -82,7 +82,7 @@
             "series": "dWnDir",
             "unit": "degrees",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNDIR_25",
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
@@ -96,7 +96,7 @@
             "series": "dWnSpd",
             "unit": "mps",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNSPD_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -25,7 +25,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -39,7 +39,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -54,7 +54,7 @@
             "unit": "meter",
             "datum": "MLLW",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_PWL_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -68,7 +68,7 @@
             "series": "dSurge",
             "unit": "meter",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "POC_Surge_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
@@ -82,7 +82,7 @@
             "series": "dWnDir",
             "unit": "degrees",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNDIR_25",
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
@@ -96,7 +96,7 @@
             "series": "dWnSpd",
             "unit": "mps",
             "interval": 3600,
-            "range": [0, -26],
+            "range": [1, -26],
             "outKey": "PL_WNSPD_25",
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",

--- a/data/dspec/TestModels/test_CRPS_120hr.json
+++ b/data/dspec/TestModels/test_CRPS_120hr.json
@@ -30,7 +30,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_water-temp_25",
@@ -51,7 +51,7 @@
             "unit": "celsius",
             "interval": 3600,
             "range": [
-                0,
+                1,
                 -26
             ],
             "outKey": "south-bird-island_air-temp_25",


### PR DESCRIPTION
Requesting an hour of lighthouse data into the future, merging into the branch that this fix depends on. If you test right now it will say that there are still nans in the series when it reaches validation. Just want to separate concerns and have people double check that all relevant lighthouse calls are extended into the future. Further testing to do once merged but I ran a few on the other branch and seems to work as expected. The other ticket regarding indexes should stay as 2, 27 because this point would fall at index 27 and the slice is exclusive. 

<img width="1440" height="960" alt="image" src="https://github.com/user-attachments/assets/1b29473c-1205-4fac-adc5-b61132f4fdaa" />
