### PR TITLE
Configuring docker watch

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -49,4 +49,4 @@ USER ${SERVICE_ACCOUNT_USERNAME}
 WORKDIR /app/src
 
 # Set the command to run the apiDriver.py script when the Docker container starts
-CMD ["uvicorn", "API.apiDriver:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "./API/semaphore_api_log_config.json", "--workers", "8"]
+CMD ["uvicorn", "API.apiDriver:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "./API/semaphore_api_log_config.json", "--workers", "8",  "--reload"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -47,6 +47,3 @@ USER ${SERVICE_ACCOUNT_USERNAME}
 
 # Set the work directory to SRC such that imports work correctly
 WORKDIR /app/src
-
-# Set the command to run the apiDriver.py script when the Docker container starts
-CMD ["uvicorn", "API.apiDriver:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "./API/semaphore_api_log_config.json", "--workers", "8",  "--reload"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,24 @@
+services:
+  core:
+    develop:
+      watch:
+        - action: sync
+          path: ./src
+          target: /app/src
+        - action: sync
+          path: ./tools
+          target: /app/tools
+        - action: rebuild
+          path: ./.env
+
+  api:
+    develop:
+      watch:
+        - action: sync
+          path: ./src
+          target: /app/src
+        - action: sync
+          path: ./tools
+          target: /app/tools
+        - action: rebuild
+          path: ./.env

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,6 +12,13 @@ services:
           path: ./.env
 
   api:
+    command: [
+      "uvicorn", "API.apiDriver:app",
+      "--host", "0.0.0.0",
+      "--port", "8000",
+      "--log-config", "./API/semaphore_api_log_config.json",
+      "--reload"
+    ]
     develop:
       watch:
         - action: sync

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,13 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   api:
+    command: [
+      "uvicorn", "API.apiDriver:app",
+      "--host", "0.0.0.0",
+      "--port", "8000",
+      "--log-config", "./API/semaphore_api_log_config.json",
+      "--workers", "8"
+    ]
     container_name: semaphore-api
     platform: linux/amd64
     build:

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -28,8 +28,8 @@ git fetch origin --tags --prune --prune-tags
 git checkout "$DEPLOY_TAG"
 
 # Build new images and raise containers
-docker compose build
-docker compose up -d
+docker compose -f ./docker-compose.yml build
+docker compose -f ./docker-compose.yml up -d
 
 # Update the cron file on the VM
 python3 tools/init_cron.py -r ./data/dspec -i ./schedule

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -19,7 +19,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=== Deployment started at $(date '+%Y-%m-%d %H:%M:%S') with tag: $DEPLOY_TAG ===" | tee -a "$LOG_FILE"
 
 # Lower active containers
-docker compose-f ./docker-compose.yml  down
+docker compose -f ./docker-compose.yml down
 
 # Fetch origin            vvvvvv - This will delete any tags that origin has deleted
 git fetch origin --tags --prune --prune-tags

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -19,7 +19,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=== Deployment started at $(date '+%Y-%m-%d %H:%M:%S') with tag: $DEPLOY_TAG ===" | tee -a "$LOG_FILE"
 
 # Lower active containers
-docker compose down
+docker compose-f ./docker-compose.yml  down
 
 # Fetch origin            vvvvvv - This will delete any tags that origin has deleted
 git fetch origin --tags --prune --prune-tags


### PR DESCRIPTION
## What is this?
A gift. We are long over due to have a porperly configured watch. With this new set up you dont have to rebuild the containers every time you make a change. Making a change on your computer will trigger both the api and semaphore core to update themselves.


## How can I test out this rad new feature?
Basically all thats changing is this idea of a "watch" a watch attaches your containers to a shell watching your file system.

 - `docker compose up --build --watch` Is an all in run command that just builds and watches
 - `docker compose up -d --build` then `docker compose watch` is two lines but the first builds the containers to run in the background and the second attaches your watch. 

Now as you edit the code you should see your terminal reporting that its updating things. An easy way of proving that this works is editing the APIs / endpoint or its healthcheck and then running them.

## Specifics 
This PR does three things.
1. Configures a docker-compose.override.yml file with the watch config.
2. Updates the API to restart itself when it detects the file system has changed.
3. Updates the deployment file to ensure it doesn't load with watch


### docker-compose.override.yml 
In a lot of code bases you will see `docker-compose.dev.yml` and `docker-compose.prod.yml` for other languages this paradigm is really powerful. Think something like Next.js where you want to run a development server with development dependencies. this paradigm allows you to containerize both your dev and prod environments. It also allows you to keep stuff like watch out of your prod build toolchain. We don't have this setup and honestly we don't need it, but afaik its still best practice to keep the watch out of prod. So the way I archived this is with an override compose file. When you just run `docker compose command` It will see our `docker-compose.yml` file and our `docker-compose.override.yml` file. It merges them. If you just want the normal docker compose file you can use the `-f [file]` argument to force it to ignore the override file. I choose this because 1. It keeps the developer experience as similar as it can to what we are used to and 2. it allows us to cleanly avoid putting watch in prod.

### Configuring the watch
Looking in the `docker-compose.override.yml` file you are greeted with this for the core service.
```yaml
services:
  core:
    develop:
      watch:
        - action: sync
          path: ./src
          target: /app/src
        - action: sync
          path: ./tools
          target: /app/tools
        - action: rebuild
          path: ./.env
```

Under develop I have configured the watch group. There I placed a list of different things to watch and what to do if it sees a change.

- `action` Is what to do if there is a change. sync means just send the file into the container, rebuild triggers the full build. For most cases sync is enough. Because core is triggered through docker exec as long as the files are synced before you run docker exec the new code will be used.
- `path` This is the path on your machine to look for changes in.
- `target` This is the path in the container to update with the changes

Why not watch everything?
You generally want to avoid watching two things. 1. Fast moving files like logs. 2. Large files like models. (Models and dspecs are already in a shared volume so their updates are already reflected in the container.) The point is we only want to watch things that would actually change how the container behaves.

Why do we rebuild on .env?
The .env variables need to be loaded into the containers environment which requires it to rebuild afaik.

### API restart
Syncing was enough for core because it has to be triggered by docker exec. However the API is running as a webserver. If we want it to reflect changes we need it to restart when we sync. We can get around having to trigger a rebuild by running Uvicorn with the `--reload` which literally sets it up to watch its file system inside the container and when we sync, it sees a change has occurred and restarts.
