### PR TITLE
API endpoint added

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, HTTPException, Query
 from datetime import datetime, timedelta, timezone
 from DataClasses import SeriesDescription, SemaphoreSeriesDescription, TimeDescription, Series
 from SeriesProvider.SeriesProvider import SeriesProvider
+from ModelExecution.statistics import Statistics
 from fastapi.encoders import jsonable_encoder
 import pandas as pd
 import numpy as np
@@ -144,9 +145,7 @@ async def get_outputs_latest(modelNames: list[str] = Query(None)):
     return serializedResults
 
 @app.get('/output_statistics/')
-async def get_outputs_statistics(
-    modelNames: list[str] = Query(None)
-):
+async def get_output_statistics(modelNames: list[str] = Query(None)):
     """
     Queries output statistics for given models.
      Args:
@@ -157,33 +156,17 @@ async def get_outputs_statistics(
         minimum, maximum, mean, and standard deviation.
 
     """
-
-    try:
-        if not modelNames:
-            raise HTTPException(
-                status_code=422,
-                detail='No model names were provided'
-            )
-
-        provider = SeriesProvider()
-
-        results = provider.request_output(
-            'STATISTICS',
-            model_names=modelNames
-        )
-
-        return results
-
-    except HTTPException:
-        raise
-
-    except Exception as e:
-        print(f"Error retrieving output statistics: {e}")
-
+    if not modelNames:
         raise HTTPException(
-            status_code=500,
-            detail="Failed to retrieve output statistics"
+            status_code=422,
+            detail='No model names were provided'
         )
+
+    statistics_class = Statistics()
+
+    statistics_results = (statistics_class.retrieve_statistics(modelNames))
+
+    return serialize_statistics( statistics_results, modelNames)
 
 @app.get('/output_time_span/')
 async def get_outputs_time_span(fromDateTime: str, toDateTime: str, modelNames: list[str] = Query(None)):
@@ -419,4 +402,45 @@ def serialize_output_series(series: Series) -> dict[any]:
 
     serialized['_Series__data'] = serialized_data # Add it back to the response
     return serialized
+
+def serialize_statistics(statistics_results: list[dict] | None, requested_model_names: list[str]) -> dict:
+    """
+    Serializes statistics results so that every requested model name
+    is included in the response, even if no statistics exist for it.
+    """
+
+    if statistics_results is None:
+        return {
+            model_name: None
+            for model_name in requested_model_names
+        }
+
+    # Build lookup table
+    statistics_by_model = {}
+
+    for stats in statistics_results:
+        statistics_by_model[stats['modelName']] = {
+            'modelName': stats['modelName'],
+            'timeGenerated': jsonable_encoder(stats['timeGenerated'].replace(tzinfo=None) if stats.get('timeGenerated') is not None else None ),
+            'p1': stats['p1'],
+            'p5': stats['p5'],
+            'p10': stats['p10'],
+            'p25': stats['p25'],
+            'p50': stats['p50'],
+            'p75': stats['p75'],
+            'p90': stats['p90'],
+            'p95': stats['p95'],
+            'p99': stats['p99'],
+            'min': stats['min'],
+            'max': stats['max'],
+            'mean': stats['mean'],
+            'std_dev': stats['std_dev']
+        }
+
+    # Ensure all requested models exist
+    serialized_results = {}
+
+    for model_name in requested_model_names:
+        serialized_results[model_name] = (statistics_by_model.get(model_name))
+    return serialized_results
 #endregion

--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -112,7 +112,7 @@ async def get_input(source: str, series: str, location: str, fromDateTime: str, 
 @app.get('/output_latest/')
 async def get_outputs_latest(modelNames: list[str] = Query(None)):
     """
-    Queries outputs for a given models looking for the last prediction that was made with them.
+    Queries outputs for given models looking for the last prediction that was made with them.
     Args:
         - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
 
@@ -143,6 +143,47 @@ async def get_outputs_latest(modelNames: list[str] = Query(None)):
     
     return serializedResults
 
+@app.get('/output_statistics/')
+async def get_outputs_statistics(
+    modelNames: list[str] = Query(None)
+):
+    """
+    Queries output statistics for given models.
+     Args:
+        - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
+    Returns:
+    - A list of dictionaries containing these statistics for each model:
+        model name, time generated, percentile values (p1-p99),
+        minimum, maximum, mean, and standard deviation.
+
+    """
+
+    try:
+        if not modelNames:
+            raise HTTPException(
+                status_code=422,
+                detail='No model names were provided'
+            )
+
+        provider = SeriesProvider()
+
+        results = provider.request_output(
+            'STATISTICS',
+            model_names=modelNames
+        )
+
+        return results
+
+    except HTTPException:
+        raise
+
+    except Exception as e:
+        print(f"Error retrieving output statistics: {e}")
+
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve output statistics"
+        )
 
 @app.get('/output_time_span/')
 async def get_outputs_time_span(fromDateTime: str, toDateTime: str, modelNames: list[str] = Query(None)):

--- a/src/ModelExecution/statistics.py
+++ b/src/ModelExecution/statistics.py
@@ -12,6 +12,8 @@ a given dataset.
 """ 
 #----------------------------------
 import numpy as np
+from SeriesStorage.ISeriesStorage import series_storage_factory
+from DataClasses import Series
 
 
 class Statistics:
@@ -71,3 +73,12 @@ class Statistics:
             statistics[key] = float(statistics[key])
 
         return statistics
+    
+    def retrieve_statistics(self, model_names: list[str]) -> Series | list[Series] | None:
+        '''
+            Retrieve statistics for the list of models passed.
+        
+        '''
+        self.seriesStorage = series_storage_factory()
+        return self.seriesStorage.select_latest_output_statistics(model_names)
+

--- a/src/ModelExecution/statistics.py
+++ b/src/ModelExecution/statistics.py
@@ -74,7 +74,7 @@ class Statistics:
 
         return statistics
     
-    def retrieve_statistics(self, model_names: list[str]) -> Series | list[Series] | None:
+    def retrieve_statistics(self, model_names: list[str]) -> list[dict] | None:
         '''
             Retrieve statistics for the list of models passed.
         

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -103,6 +103,12 @@ class SeriesProvider():
                     return self.seriesStorage.select_specific_output(**kwargs)
                 except TypeError:
                     raise Semaphore_Exception(f'Method {method} in SeriesProvider.request_output received {kwargs} call should be formatted like request_output("SPECIFIC", semaphoreSeriesDescription= DESCRIPTION, timeDescription= DESCRIPTION)')
+            case 'STATISTICS':
+                try:
+                    return self.seriesStorage.select_latest_output_statistics(**kwargs)
+                except TypeError:
+                    raise Semaphore_Exception(f'Method {method} in SeriesProvider.request_output received {kwargs} call should be formatted like request_output("STATISTICS", semaphoreSeriesDescription= DESCRIPTION, timeDescription= DESCRIPTION)')
+            
             case _:
                 raise NotImplementedError(f'Method {method} has not been implemented in SeriesProvider.request_output')
     def db_has_freshly_acquired_data(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, referenceTime: datetime) -> bool:

--- a/src/SeriesProvider/SeriesProvider.py
+++ b/src/SeriesProvider/SeriesProvider.py
@@ -103,12 +103,6 @@ class SeriesProvider():
                     return self.seriesStorage.select_specific_output(**kwargs)
                 except TypeError:
                     raise Semaphore_Exception(f'Method {method} in SeriesProvider.request_output received {kwargs} call should be formatted like request_output("SPECIFIC", semaphoreSeriesDescription= DESCRIPTION, timeDescription= DESCRIPTION)')
-            case 'STATISTICS':
-                try:
-                    return self.seriesStorage.select_latest_output_statistics(**kwargs)
-                except TypeError:
-                    raise Semaphore_Exception(f'Method {method} in SeriesProvider.request_output received {kwargs} call should be formatted like request_output("STATISTICS", semaphoreSeriesDescription= DESCRIPTION, timeDescription= DESCRIPTION)')
-            
             case _:
                 raise NotImplementedError(f'Method {method} has not been implemented in SeriesProvider.request_output')
     def db_has_freshly_acquired_data(self, seriesDescription: SeriesDescription, timeDescription: TimeDescription, referenceTime: datetime) -> bool:


### PR DESCRIPTION
# Objective:
We need to be able to retrieve statistics from the semaphore database. The solution to this is creating an api endpoint that will retrieve statistics for each model given.

# Testing: 
 -  docker compose up -d --build
 - docker exec semaphore-core python3 tools/migrate_db.py   
 - Populate the DB:
      -  docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_120hr.json 
      - docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/CRPS/CRPS_6hr.json       
- Go to http://localhost:8888/docs
- Retrieve statistics data from the 2 models                            
