### PR TITLE
968 magnolia series not clipping

### DIFF
--- a/data/dspec/Inundation/April/ar_inundation_apr_12h.json
+++ b/data/dspec/Inundation/April/ar_inundation_apr_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/April/ar_inundation_apr_24h.json
+++ b/data/dspec/Inundation/April/ar_inundation_apr_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/April/ar_inundation_apr_48h.json
+++ b/data/dspec/Inundation/April/ar_inundation_apr_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/August/ar_inundation_aug_12h.json
+++ b/data/dspec/Inundation/August/ar_inundation_aug_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/August/ar_inundation_aug_24h.json
+++ b/data/dspec/Inundation/August/ar_inundation_aug_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/August/ar_inundation_aug_48h.json
+++ b/data/dspec/Inundation/August/ar_inundation_aug_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/December/ar_inundation_dec_12h.json
+++ b/data/dspec/Inundation/December/ar_inundation_dec_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/December/ar_inundation_dec_24h.json
+++ b/data/dspec/Inundation/December/ar_inundation_dec_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/December/ar_inundation_dec_48h.json
+++ b/data/dspec/Inundation/December/ar_inundation_dec_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/February/ar_inundation_feb_12h.json
+++ b/data/dspec/Inundation/February/ar_inundation_feb_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/February/ar_inundation_feb_24h.json
+++ b/data/dspec/Inundation/February/ar_inundation_feb_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/February/ar_inundation_feb_48h.json
+++ b/data/dspec/Inundation/February/ar_inundation_feb_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/January/ar_inundation_jan_12h.json
+++ b/data/dspec/Inundation/January/ar_inundation_jan_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/January/ar_inundation_jan_24h.json
+++ b/data/dspec/Inundation/January/ar_inundation_jan_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/January/ar_inundation_jan_48h.json
+++ b/data/dspec/Inundation/January/ar_inundation_jan_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/July/ar_inundation_jul_12h.json
+++ b/data/dspec/Inundation/July/ar_inundation_jul_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/July/ar_inundation_jul_24h.json
+++ b/data/dspec/Inundation/July/ar_inundation_jul_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/July/ar_inundation_jul_48h.json
+++ b/data/dspec/Inundation/July/ar_inundation_jul_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/June/ar_inundation_jun_12h.json
+++ b/data/dspec/Inundation/June/ar_inundation_jun_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/June/ar_inundation_jun_24h.json
+++ b/data/dspec/Inundation/June/ar_inundation_jun_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/June/ar_inundation_jun_48h.json
+++ b/data/dspec/Inundation/June/ar_inundation_jun_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/March/ar_inundation_mar_12h.json
+++ b/data/dspec/Inundation/March/ar_inundation_mar_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/March/ar_inundation_mar_24h.json
+++ b/data/dspec/Inundation/March/ar_inundation_mar_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/March/ar_inundation_mar_48h.json
+++ b/data/dspec/Inundation/March/ar_inundation_mar_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/May/ar_inundation_may_12h.json
+++ b/data/dspec/Inundation/May/ar_inundation_may_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/May/ar_inundation_may_24h.json
+++ b/data/dspec/Inundation/May/ar_inundation_may_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/May/ar_inundation_may_48h.json
+++ b/data/dspec/Inundation/May/ar_inundation_may_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/November/ar_inundation_nov_12h.json
+++ b/data/dspec/Inundation/November/ar_inundation_nov_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/November/ar_inundation_nov_24h.json
+++ b/data/dspec/Inundation/November/ar_inundation_nov_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/November/ar_inundation_nov_48h.json
+++ b/data/dspec/Inundation/November/ar_inundation_nov_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/October/ar_inundation_oct_12h.json
+++ b/data/dspec/Inundation/October/ar_inundation_oct_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/October/ar_inundation_oct_24h.json
+++ b/data/dspec/Inundation/October/ar_inundation_oct_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/October/ar_inundation_oct_48h.json
+++ b/data/dspec/Inundation/October/ar_inundation_oct_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/September/ar_inundation_sep_12h.json
+++ b/data/dspec/Inundation/September/ar_inundation_sep_12h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_12",
                 "warning_trigger": "20",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_12",
                 "warning_trigger": "11",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/September/ar_inundation_sep_24h.json
+++ b/data/dspec/Inundation/September/ar_inundation_sep_24h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_24",
                 "warning_trigger": "40",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_24",
                 "warning_trigger": "23",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Inundation/September/ar_inundation_sep_48h.json
+++ b/data/dspec/Inundation/September/ar_inundation_sep_48h.json
@@ -68,7 +68,7 @@
             "args": {
                 "target_inKey": "DPD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_DPD_1" 
+                "outKey": "fmm_DPD_1" 
                      
             }
         },
@@ -77,7 +77,7 @@
             "args": {
                 "target_inKey": "APD_48",
                 "warning_trigger": "90",
-                "outkey": "fmm_APD_1" 
+                "outKey": "fmm_APD_1" 
                      
             }
         },
@@ -86,7 +86,7 @@
             "args": {
                 "target_inKey": "WVHT_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_WVHT_1" 
+                "outKey": "fmm_WVHT_1" 
                      
             }
         },
@@ -95,7 +95,7 @@
             "args": {
                 "target_inKey": "dWl_48",
                 "warning_trigger": "47",
-                "outkey": "fmm_dWl_1" 
+                "outKey": "fmm_dWl_1" 
                      
             }
         }

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -160,7 +160,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_PWL_25",
                 "targetAvgSecond_inKey": "POC_PWL_25",
-                "avg_outkey": "AVG_PWL_25"
+                "avg_outKey": "AVG_PWL_25"
             }
         },
         {
@@ -168,7 +168,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_Surge_25",
                 "targetAvgSecond_inKey": "POC_Surge_25",
-                "avg_outkey": "AVG_Surge_25"
+                "avg_outKey": "AVG_Surge_25"
             }
         }
     ],

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -160,7 +160,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_PWL_25",
                 "targetAvgSecond_inKey": "POC_PWL_25",
-                "avg_outkey": "AVG_PWL_25"
+                "avg_outKey": "AVG_PWL_25"
             }
         },
         {
@@ -168,7 +168,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_Surge_25",
                 "targetAvgSecond_inKey": "POC_Surge_25",
-                "avg_outkey": "AVG_Surge_25"
+                "avg_outKey": "AVG_Surge_25"
             }
         }
     ],

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -160,7 +160,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_PWL_25",
                 "targetAvgSecond_inKey": "POC_PWL_25",
-                "avg_outkey": "AVG_PWL_25"
+                "avg_outKey": "AVG_PWL_25"
             }
         },
         {
@@ -168,7 +168,7 @@
             "args": {
                 "targetAvgFirst_inKey": "PL_Surge_25",
                 "targetAvgSecond_inKey": "POC_Surge_25",
-                "avg_outkey": "AVG_Surge_25"
+                "avg_outKey": "AVG_Surge_25"
             }
         }
     ],

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_6",
                 "targetSecond_inKey": "PWL_PAST_6",
-                "outkey": "SURGE_PAST_6"    
+                "outKey": "SURGE_PAST_6"    
             }
         }
     ],

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_6",
                 "targetSecond_inKey": "PWL_PAST_6",
-                "outkey": "SURGE_PAST_6"    
+                "outKey": "SURGE_PAST_6"    
             }
         }
     ],

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_6",
                 "targetSecond_inKey": "PWL_PAST_6",
-                "outkey": "SURGE_PAST_6"    
+                "outKey": "SURGE_PAST_6"    
             }
         }
     ],

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
@@ -162,7 +162,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -171,7 +171,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_12",
                 "targetSecond_inKey": "PWL_PAST_12",
-                "outkey": "SURGE_PAST_12"    
+                "outKey": "SURGE_PAST_12"    
             }
         }
     ],

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
@@ -178,7 +178,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_NOW_1",
                 "targetSecond_inKey": "PWL_NOW_1",
-                "outkey": "SURGE_NOW_1"    
+                "outKey": "SURGE_NOW_1"    
             }
         },
         {
@@ -187,7 +187,7 @@
                 "op": "subtraction",
                 "targetFirst_inKey": "DWL_PAST_6",
                 "targetSecond_inKey": "PWL_PAST_6",
-                "outkey": "SURGE_PAST_6"    
+                "outKey": "SURGE_PAST_6"    
             }
         }
     ],

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -155,8 +155,8 @@ def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: list
         # Key is not in vectorOrder — search post-process calls for one that
         # consumes this key as an inKey, then return the indexes of its outKey
         for call in postProcessCalls:
-            in_keys  = [v for k, v in call.args.items() if k.endswith('_inKey')]
-            out_keys = [v for k, v in call.args.items() if k.endswith('_outKey')]
+            in_keys  = [v for k, v in call.args.items() if k.lower().endswith('_inkey')]
+            out_keys = [v for k, v in call.args.items() if k.lower().endswith('_outkey')]
             if key in in_keys:
                 for out_key in out_keys:
                     if out_key in key_to_index:

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -68,7 +68,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]], postProcessCalls: list[PostProcessCall]) -> dict[str, Series]:
+    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]], postProcessCalls: list[PostProcessCall]) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description
@@ -135,7 +135,7 @@ def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], r
         return series_repository
 
 
-def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: list[PostProcessCall]) -> tuple | None:
+    def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: list[PostProcessCall]) -> tuple | None:
         """Resolves the vectorOrder indexes for a given key. If the key is directly in
         vectorOrder, returns its indexes. If the key is only consumed by a post-process
         call (i.e. not in vectorOrder directly), walks the post-process args to find the
@@ -214,7 +214,7 @@ def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: list
         This function calls the post processing methods for any inputs that need post processing.
         The post_process_data function is passed the input dictionary and the process call
         so that the function can easily find the series needed for the computation and return 
-        a dictionary with the new outkeys and series. 
+        a dictionary with the new outKeys and series. 
 
         :param series_repository: dict[str, Series] - The dictionary of the data it collected
         :param postProcessCalls: list[PostProcessCall] - The list of post processing calls to execute

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -135,7 +135,7 @@ def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], r
         return series_repository
 
 
-    def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: dict[str, Series]) -> tuple | None:
+def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: list[PostProcessCall]) -> tuple | None:
         """Resolves the vectorOrder indexes for a given key. If the key is directly in
         vectorOrder, returns its indexes. If the key is only consumed by a post-process
         call (i.e. not in vectorOrder directly), walks the post-process args to find the

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -60,7 +60,7 @@ class DataGatherer:
         key_to_index = dict(zip(vector_order.keys, vector_order.indexes))
         
         # Get Dependent Data
-        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime, key_to_index)
+        dependent_data_repository = self.__request_dependent_data(dependentSeries, referenceTime, key_to_index, postProcessCalls)
 
         # Call post processing 
         post_processed_series_repository = self.__post_process_data(dependent_data_repository, postProcessCalls)
@@ -68,7 +68,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]]) -> dict[str, Series]:
+    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]], postProcessCalls: dict[str, Series]) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description
@@ -126,8 +126,7 @@ class DataGatherer:
 
             # Validate only the rows the model will actually consume, not the full
             # over-requested window including interpolation buffer slots.
-            series = self.__clip_series(series, key, key_to_index.get(key), referenceTime)
-
+            series = self.__clip_series(series, key, self.__resolve_indexes(key, key_to_index, dependentSeriesList, postProcessCalls), referenceTime)
             self.__validate_series(series, referenceTime)
             
             # Clipped Series (only points that the model actually wants) goes in the repo
@@ -135,6 +134,35 @@ class DataGatherer:
 
         return series_repository
 
+
+    def __resolve_indexes(self, key: str, key_to_index: dict, dependentSeriesList: list[DependentSeries], postProcessCalls: dict[str, Series]) -> tuple | None:
+        """Resolves the vectorOrder indexes for a given key. If the key is directly in
+        vectorOrder, returns its indexes. If the key is only consumed by a post-process
+        call (i.e. not in vectorOrder directly), walks the post-process args to find the
+        outKey that this key feeds into, then returns that outKey's indexes.
+
+        Relies on the convention that post-process args use '_inKey' and '_outKey' suffixes.
+
+        :param key: str - The outKey of the dependent series to resolve indexes for
+        :param key_to_index: dict - The vectorOrder key -> indexes mapping
+        :param postProcessCalls: list[PostProcessCall] - The post-process calls from the dspec
+        :returns: tuple | None - The (start, end) index tuple, or None if unresolvable
+        """
+        # Direct hit — key is in vectorOrder
+        if key in key_to_index:
+            return key_to_index[key]
+
+        # Key is not in vectorOrder — search post-process calls for one that
+        # consumes this key as an inKey, then return the indexes of its outKey
+        for call in postProcessCalls:
+            in_keys  = [v for k, v in call.args.items() if k.endswith('_inKey')]
+            out_keys = [v for k, v in call.args.items() if k.endswith('_outKey')]
+            if key in in_keys:
+                for out_key in out_keys:
+                    if out_key in key_to_index:
+                        return key_to_index[out_key]
+
+        return None
 
     def __clip_series(self, series: Series, key: str, index: list[int] | None, referenceTime: datetime):
         """Clips the series to the rows the model will actually consume according to

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -68,7 +68,7 @@ class DataGatherer:
         return post_processed_series_repository
     
 
-    def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]], postProcessCalls: dict[str, Series]) -> dict[str, Series]:
+def __request_dependent_data(self, dependentSeriesList: list[DependentSeries], referenceTime: datetime, key_to_index: dict[str, list[int]], postProcessCalls: list[PostProcessCall]) -> dict[str, Series]:
         """This method handles the process of requesting the dependant series from the DSPEC. Its requests will be temporally
         referenced from the passed reference time. It will:
             - Build the series description

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -147,6 +147,11 @@ class DataGatherer:
         :param key_to_index: dict - The vectorOrder key -> indexes mapping
         :param postProcessCalls: list[PostProcessCall] - The post-process calls from the dspec
         :returns: tuple | None - The (start, end) index tuple, or None if unresolvable
+        
+        NOTE: This method will not work for series that feed into multiple post-process calls, 
+              or for post-process calls that consume multiple series and produce multiple outKeys.
+              Right now we restrict the chain of keys to a 2 level chain and this will have to be 
+              fixed later on if a series must go through more than one post processing class. 
         """
         # Direct hit — key is in vectorOrder
         if key in key_to_index:

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -124,9 +124,15 @@ class DataGatherer:
             # Reset the index
             series.dataFrame.reset_index(inplace=True)
 
+            # Resolve the vectorOrder indexes for the series, either directly or through post-process calls. 
+            # This is used to clip the series before validation so that interpolation buffer slots do not cause false positives.
+            resolved = self.__resolve_indexes(key, key_to_index, postProcessCalls)
+            if resolved is None:
+                log(f'[DataGatherer] Warning: key "{key}" is not in vectorOrder and could not be resolved through post-process calls. Validating full series.')
+           
             # Validate only the rows the model will actually consume, not the full
             # over-requested window including interpolation buffer slots.
-            series = self.__clip_series(series, key, self.__resolve_indexes(key, key_to_index, postProcessCalls), referenceTime)
+            series = self.__clip_series(series, key, resolved, referenceTime)
             self.__validate_series(series, referenceTime)
             
             # Clipped Series (only points that the model actually wants) goes in the repo

--- a/src/ModelExecution/dataGatherer.py
+++ b/src/ModelExecution/dataGatherer.py
@@ -126,7 +126,7 @@ class DataGatherer:
 
             # Validate only the rows the model will actually consume, not the full
             # over-requested window including interpolation buffer slots.
-            series = self.__clip_series(series, key, self.__resolve_indexes(key, key_to_index, dependentSeriesList, postProcessCalls), referenceTime)
+            series = self.__clip_series(series, key, self.__resolve_indexes(key, key_to_index, postProcessCalls), referenceTime)
             self.__validate_series(series, referenceTime)
             
             # Clipped Series (only points that the model actually wants) goes in the repo
@@ -135,7 +135,7 @@ class DataGatherer:
         return series_repository
 
 
-    def __resolve_indexes(self, key: str, key_to_index: dict, dependentSeriesList: list[DependentSeries], postProcessCalls: dict[str, Series]) -> tuple | None:
+    def __resolve_indexes(self, key: str, key_to_index: dict, postProcessCalls: dict[str, Series]) -> tuple | None:
         """Resolves the vectorOrder indexes for a given key. If the key is directly in
         vectorOrder, returns its indexes. If the key is only consumed by a post-process
         call (i.e. not in vectorOrder directly), walks the post-process args to find the

--- a/src/ModelExecution/dspecParser.py
+++ b/src/ModelExecution/dspecParser.py
@@ -256,7 +256,7 @@ class DependentSeries:
         
         
     def __str__(self) -> str:
-        return f'\n[DependentSeries] -> name: {self.name}, location: {self.location}, source: {self.source}, series: {self.series}, unit: {self.unit}, datum: {self.datum}, range: {self.range}, outkey: {self.outKey}, dataIntegrityCall: {self.dataIntegrityCall}, verificationOverride: {self.verificationOverride}, stalenessOffset: {self.stalenessOffset}'
+        return f'\n[DependentSeries] -> name: {self.name}, location: {self.location}, source: {self.source}, series: {self.series}, unit: {self.unit}, datum: {self.datum}, range: {self.range}, outKey: {self.outKey}, dataIntegrityCall: {self.dataIntegrityCall}, verificationOverride: {self.verificationOverride}, stalenessOffset: {self.stalenessOffset}'
 
     def __repr__(self):
         return f'\nDependentSeries({self.name}, {self.location}, {self.source}, {self.series}, {self.unit}, {self.datum}, {self.range}, {self.outKey},{self.dataIntegrityCall}, {self.verificationOverride}, {self.stalenessOffset})'

--- a/src/PostProcessing/IPostProcessing.py
+++ b/src/PostProcessing/IPostProcessing.py
@@ -29,7 +29,7 @@ class IPostProcessing(ABC):
             NotImplementedError: An error will appear when the function haas not been implemented
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
         raise NotImplementedError
     

--- a/src/PostProcessing/PostProcessingClasses/ArithmeticOperation.py
+++ b/src/PostProcessing/PostProcessingClasses/ArithmeticOperation.py
@@ -34,7 +34,7 @@ class ArithmeticOperation(IPostProcessing):
                 op - the operation to preform (ex. addition)
                 targetFirst_inKey - The key for the first series.
                 targetSecond_inKey - The key for the second series.
-                outkey - The key to save the series as.
+                outKey - The key to save the series as.
 
         json_copy:
         {
@@ -43,7 +43,7 @@ class ArithmeticOperation(IPostProcessing):
                 "op": "",
                 "targetFirst_inKey": "",
                 "targetSecond_inKey": "",
-                "outkey": "" 
+                "outKey": "" 
                      
             }
         },
@@ -57,7 +57,7 @@ class ArithmeticOperation(IPostProcessing):
             postProcessCall (PostProcessCall): The type of post processing the model requires. Located in the dspec.
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
 
         # Unpack arguments from arg object
@@ -65,7 +65,7 @@ class ArithmeticOperation(IPostProcessing):
         OPERATION = args['op']
         FIRST_SERIES = preprocessedData[args['targetFirst_inKey']]
         SECOND_SERIES = preprocessedData[args['targetSecond_inKey']]
-        OUT_KEY = args['outkey']
+        OUT_KEY = args['outKey']
         
         # Unpack the data
         first_data = FIRST_SERIES.dataFrame['dataValue'].astype(float).to_numpy()

--- a/src/PostProcessing/PostProcessingClasses/Average.py
+++ b/src/PostProcessing/PostProcessingClasses/Average.py
@@ -23,7 +23,7 @@ class Average(IPostProcessing):
         args: 
                 targetAvgFirst_inKey - The key for the first series.
                 targetAvgSecond_inKey - The key for the second series.
-                avg_outkey - The key to save the series of averages as.
+                avg_outKey - The key to save the series of averages as.
 
         json_copy:
         {
@@ -31,7 +31,7 @@ class Average(IPostProcessing):
             "args": {
                 "targetAvgFirst_inKey": "",
                 "targetAvgSecond_inKey": "",
-                "avg_outkey": "" 
+                "avg_outKey": "" 
                      
             }
         },
@@ -45,7 +45,7 @@ class Average(IPostProcessing):
             postProcessCall (PostProcessCall): The type of post processing the model requires. Located in the dspec.
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
 
         # Unpack arguments from arg object
@@ -68,7 +68,7 @@ class Average(IPostProcessing):
 
         # Repack average as new series, reading the key from the arguments obj
         desc = first_series.description
-        average_outKey = args['avg_outkey']
+        average_outKey = args['avg_outKey']
         desc.dataSeries = average_outKey
         a_series = Series(desc, first_series.timeDescription)
         a_series.dataFrame = df_result

--- a/src/PostProcessing/PostProcessingClasses/FourMaxMean.py
+++ b/src/PostProcessing/PostProcessingClasses/FourMaxMean.py
@@ -27,7 +27,7 @@ class FourMaxMean(IPostProcessing):
                 target_inKey - The key for the to preform the operation on series.
                 warning_trigger - Parsed as int. If amount of data is less than this value before 
                     fmm a warning will be triggered.
-                outkey - The key to save the series of four max mean as.
+                outKey - The key to save the series of four max mean as.
 
         json_copy:
         {
@@ -35,7 +35,7 @@ class FourMaxMean(IPostProcessing):
             "args": {
                 "target_inKey": "",
                 "warning_trigger": "",
-                "outkey": "" 
+                "outKey": "" 
                      
             }
         },
@@ -49,14 +49,14 @@ class FourMaxMean(IPostProcessing):
             postProcessCall (PostProcessCall): The type of post processing the model requires. Located in the dspec.
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
 
         # Unpack data and arguments from arg object
         args = postProcessCall.args
         IN_SERIES = preprocessedData[args['target_inKey']]
         IN_SERIES_DATA = IN_SERIES.dataFrame['dataValue'].astype(float).to_list()
-        OUT_KEY = args['outkey']
+        OUT_KEY = args['outKey']
 
         # filter out any NaN values
         filtered_data = [value for value in IN_SERIES_DATA if not pd.isna(value)]

--- a/src/PostProcessing/PostProcessingClasses/MagnoliaPredictionsPostProcess.py
+++ b/src/PostProcessing/PostProcessingClasses/MagnoliaPredictionsPostProcess.py
@@ -46,7 +46,7 @@ class MagnoliaPredictionsPostProcess(IPostProcessing):
             postProcessCall (PostProcessCall): The type of post processing the model requires. Located in the dspec.
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
 
         # Unpack arguments from arg object
@@ -78,10 +78,10 @@ class MagnoliaPredictionsPostProcess(IPostProcessing):
         # Repack transformed values in a new Series
         desc = magnolia_Preds.description
 
-        transformed_outkey = args['Magnolia_WL_outKey']
-        desc.dataSeries = transformed_outkey
+        transformed_outKey = args['Magnolia_WL_outKey']
+        desc.dataSeries = transformed_outKey
         transformed_series = Series(desc, magnolia_predHarmSecond.timeDescription)
         transformed_series.dataFrame = df_result
-        preprocessedData[transformed_outkey] = transformed_series
+        preprocessedData[transformed_outKey] = transformed_series
 
         return preprocessedData

--- a/src/PostProcessing/PostProcessingClasses/ResolveVectorComponents.py
+++ b/src/PostProcessing/PostProcessingClasses/ResolveVectorComponents.py
@@ -51,7 +51,7 @@ class ResolveVectorComponents(IPostProcessing):
             postProcessCall (PostProcessCall): The type of post processing the model requires. Located in the dspec.
 
         Returns:
-            dict[key, Series]: A dictionary with the new preprocessed series and their outkeys
+            dict[key, Series]: A dictionary with the new preprocessed series and their outKeys
         """
 
         # Unpack arguments from arg object

--- a/src/tests/UnitTests/test_ArithmeticOperation.py
+++ b/src/tests/UnitTests/test_ArithmeticOperation.py
@@ -68,7 +68,7 @@ def test_post_process_data(test_preprocess_data, operation, expected_results):
                 "op": operation,
                 "targetFirst_inKey": "first",
                 "targetSecond_inKey": "second",
-                "outkey": "result"  
+                "outKey": "result"  
             }
 
     # Call the factory to get the resolver and pass it the fake input data and the post process call

--- a/src/tests/UnitTests/test_Average.py
+++ b/src/tests/UnitTests/test_Average.py
@@ -53,7 +53,7 @@ def test_post_process_data():
     ppc.args = {
                 "targetAvgFirst_inKey": "first",
                 "targetAvgSecond_inKey": "second",
-                "avg_outkey": "avg"    
+                "avg_outKey": "avg"    
             }
 
     # Call the factory to get the resolver and pass it the fake input data and the post process call

--- a/src/tests/UnitTests/test_FourMaxMean.py
+++ b/src/tests/UnitTests/test_FourMaxMean.py
@@ -53,7 +53,7 @@ def test_post_process_data():
     ppc.args = {
                 "target_inKey": "data",
                 "warning_trigger": "0",
-                "outkey": "fmm"         
+                "outKey": "fmm"         
             }
 
     # Call the factory to get the resolver and pass it the fake input data and the post process call


### PR DESCRIPTION
## Fix `DateRangeValidation` false failures for post-processing-only dependent series

### Problem

Dependent series that are consumed exclusively by post-process calls (i.e. not listed directly in `vectorOrder`) were failing `DateRangeValidation` with false negatives.

The existing clip logic in `__clip_series` correctly trims a series to only the rows the model actually consumes before validation, using `key_to_index` (built from `vectorOrder`). However, if a series' `outKey` does not appear in `vectorOrder` — because it feeds a post-process call that produces a *different* output key — `key_to_index.get(key)` returns `None` and the clip is skipped entirely. The full over-requested window, including interpolation buffer slots, is then passed to `DateRangeValidation`.

This caused models to fail at runtime when the leading buffer slot (e.g. `T+0` or the current hour) had not yet been ingested, even though that slot is never read by the model.

**Example:** In `magnolia_12`, `PL_WNDIR_25` and `PL_WNSPD_25` both have `range: [1, -26]` and feed `ResolveVectorComponents`, which outputs `x_PL_PWNDCMP_25` / `y_PL_PWNDCMP_25`. Those derived keys appear in `vectorOrder` with `indexes: [2, 26]`, but the raw wind keys do not. At runtime (`21:59 UTC`), `toDateTime` resolved to `22:00 UTC` — a slot that didn't exist yet — causing validation to fail on wind direction while all other series passed cleanly.

### Fix

Added `__resolve_indexes` to `DataGatherer`. When a key is not found directly in `key_to_index`, the method walks `postProcessCalls` looking for a call whose args contain the key as an `_inKey` value, then returns the `key_to_index` entry for the corresponding `_outKey`. This traces the key one step through post-processing to find the indexes of the vectorOrder entry it ultimately feeds.

This relies on the existing convention that post-process args use `_inKey` / `_outKey` suffixes for their input and output key references, which is consistent across all current post-process calls.

`__request_dependent_data` was updated to call `__resolve_indexes` instead of `key_to_index.get(key)` directly, and `postProcessCalls` is now passed through from `get_data_repository`.

This is technically another work around for the [restructure](https://github.com/conrad-blucher-institute/semaphore/issues/919#issuecomment-4359064516) that we spoke about the first time this issue came up, however I maintain the stance that a refactor would be more time consuming than simply solving this bug in a slightly silly way. 

### Files Changed

- `src/ModelExecution/dataGatherer.py`
  - Added `__resolve_indexes`
  - Updated `__request_dependent_data` signature to accept `postProcessCalls`
  - Updated clip call to use `__resolve_indexes`
  - Updated call site in `get_data_repository`

### Testing

1. `docker compose up -d --build`
2. `docker exec semaphore-core python3 -m pytest src/tests/ --run-slow `
3. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/Magnolia/48/magnolia_48.json -v`
4. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_102hr.json`
5. `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json`
