### PR TITLE
archive logging and docker tagging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   core:
     container_name: semaphore-core
+    image: semaphore-core:${IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.core
@@ -44,6 +45,7 @@ services:
       "--workers", "8"
     ]
     container_name: semaphore-api
+    image: semaphore-api:${IMAGE_TAG:-latest}
     platform: linux/amd64
     build:
       context: .

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -7,9 +7,19 @@
 
 # Create deployment logs directory if it doesn't exist
 mkdir -p ./logs/deployment
-
+mkdir -p ./logs/deployment/archive
 # Set up logging - capture both stdout and stderr
 LOG_FILE="./logs/deployment/$(date "+%Y")_$(date "+%m")_deployment.log"
+
+# Compress deployment logs older than 90 days
+find ./logs/deployment -maxdepth 1 -name "*.log" -mtime +90 -exec gzip {} \ ;
+
+# Move archived logs into the archive folder
+find ./logs/deployment -maxdepth 1  -name "*.gz" -exec mv {} ./logs/deployment/archive/ \;
+
+# Delete archived logs older than one year
+find ./logs/deployment/archive -name "*.gz" -mtime +365 -delete
+
 DEPLOY_TAG="$1"
 
 # Redirect all output to both console and log file
@@ -26,6 +36,9 @@ git fetch origin --tags --prune --prune-tags
 
 # Checkout correct tag
 git checkout "$DEPLOY_TAG"
+
+# Set the IMAGE_TAG environment variable to the deployment tag
+export IMAGE_TAG="$DEPLOY_TAG"
 
 # Build new images and raise containers
 docker compose -f ./docker-compose.yml build

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -12,13 +12,26 @@ mkdir -p ./logs/deployment/archive
 LOG_FILE="./logs/deployment/$(date "+%Y")_$(date "+%m")_deployment.log"
 
 # Compress deployment logs older than 90 days
-find ./logs/deployment -maxdepth 1 -name "*.log" -mtime +90 -exec gzip {} \ ;
+find ./logs/deployment -path "./logs/deployment/archive" -prune -o -name "*.log" -mtime +90 -exec gzip {} \;
 
 # Move archived logs into the archive folder
-find ./logs/deployment -maxdepth 1  -name "*.gz" -exec mv {} ./logs/deployment/archive/ \;
+find ./logs/deployment -path "./logs/deployment/archive" -prune -o -name "*.gz" -exec mv {} ./logs/deployment/archive/ \;
 
 # Delete archived logs older than one year
 find ./logs/deployment/archive -name "*.gz" -mtime +365 -delete
+
+# Create model logs directory if it doesn't exist
+mkdir -p ./data/logs
+mkdir -p ./data/logs/archive
+
+# Compress deployment logs older than 90 days
+find ./data/logs -path "./data/logs/archive" -prune -o -name "*.log" -mtime +90 -exec gzip {} \;
+
+# Move archived logs into the archive folder
+find ./data/logs -path "./data/logs/archive" -prune -o -name "*.gz" -exec mv {} ./data/logs/archive/ \;
+
+# Delete archived logs older than one year
+find ./data/logs/archive -name "*.gz" -mtime +365 -delete
 
 DEPLOY_TAG="$1"
 


### PR DESCRIPTION
# Tag Description
- Modify deployment script to tag images so that they are easier to find and flush later on
- Modify deployment script to archive log files more than three months old and delete logs older than a year


# How to test

## Log Archiving
- Create archive folder:
    - `mkdir -p logs/deployment/archive`
    
- Create fake logs:
touch ./data/logs/24hr_VirginiaKey/recent.log
touch ./data/logs/24hr_VirginiaKey/three_months.log
touch ./data/logs/24hr_VirginiaKey/one_year.log

touch logs/deployment/recent.log
touch logs/deployment/three_months.log
touch logs/deployment/one_year.log

- Change their modification dates: 
touch -d "10 days ago" ./data/logs/24hr_VirginiaKey/recent.log
touch -d "100 days ago" ./data/logs/24hr_VirginiaKey/three_months.log
touch -d "400 days ago" ./data/logs/24hr_VirginiaKey/one_year.log

touch -d "10 days ago" logs/deployment/recent.log
touch -d "100 days ago" logs/deployment/three_months.log
touch -d "400 days ago" logs/deployment/one_year.log

- Run each line added in deploy.sh and ensure it does what it claims to:
   
<img width="816" height="438" alt="image" src="https://github.com/user-attachments/assets/2321931d-cec3-4cad-a203-b06fe3168304" />

## Docker Image Tags

- Run: 
`export IMAGE_TAG=v3.7.0
docker compose -f ./docker-compose.yml build
docker compose -f ./docker-compose.yml up -d`
- Check the image: 
    
<img width="194" height="75" alt="Screenshot 2026-07-05 170331" src="https://github.com/user-attachments/assets/8e0debe2-ec85-4e9f-9e75-287b6e1728db" />
