### PR TITLE
12 and a half hour staleness rather than just 12 hours to catch smal …

### DIFF
--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_102hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_108",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_108hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_114",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_114hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_120",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_120hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_126",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_12hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_18",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_18hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_24",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_24hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_30",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_30hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_36",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_36hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_42",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_9",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_42hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_48",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_48hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_54",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_54hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_60",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_60hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_66",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_66hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_72",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_6hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_12",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_72hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_78",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_78hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_84",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_84hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_90",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_90hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_96",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Bird-Island_Water-Temperature_96hr.json
@@ -71,7 +71,7 @@
                 1
             ],
             "outKey": "south-bird-island_predicted_air-temp_102",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/MLP-OP.json
+++ b/data/dspec/MLP-OP.json
@@ -47,7 +47,7 @@
             "interval": 10800,
             "range": [16, 1],
             "outKey": "SBI_PAT_16",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [],

--- a/data/dspec/Magnolia/12/magnolia_12.json
+++ b/data/dspec/Magnolia/12/magnolia_12.json
@@ -112,7 +112,7 @@
             "interval": 3600,
             "range": [7, 1],
             "outKey": "PL_PWNDIR_F7",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": { "limit": "3600", "method": "linear", "limit_area": "inside" }
@@ -127,7 +127,7 @@
             "interval": 3600,
             "range": [7, 1],
             "outKey": "PL_PWSPD_F7",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": { "limit": "3600", "method": "linear", "limit_area": "inside" }

--- a/data/dspec/Magnolia/12/magnolia_transform_12.json
+++ b/data/dspec/Magnolia/12/magnolia_transform_12.json
@@ -46,7 +46,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "PL_WNDIR_F12",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -65,7 +65,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "PL_WNDSPD_F12",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/24/magnolia_24.json
+++ b/data/dspec/Magnolia/24/magnolia_24.json
@@ -112,7 +112,7 @@
             "interval": 3600,
             "range": [19, 1],
             "outKey": "PL_PWNDIR_F20",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": { "limit": "3600", "method": "linear", "limit_area": "inside" }
@@ -127,7 +127,7 @@
             "interval": 3600,
             "range": [19, 1],
             "outKey": "PL_PWSPD_F20",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": { "limit": "3600", "method": "linear", "limit_area": "inside" }

--- a/data/dspec/Magnolia/24/magnolia_transform_24.json
+++ b/data/dspec/Magnolia/24/magnolia_transform_24.json
@@ -46,7 +46,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "PL_WNDIR_F24",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -65,7 +65,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "PL_WNDSPD_F24",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Magnolia/48/magnolia_48.json
+++ b/data/dspec/Magnolia/48/magnolia_48.json
@@ -112,7 +112,7 @@
             "interval": 3600,
             "range": [43, 1],
             "outKey": "PL_PWNDIR_F43",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": { "limit": "7200", "method": "linear", "limit_area": "None" }
@@ -127,7 +127,7 @@
             "interval": 3600,
             "range": [43, 1],
             "outKey": "PL_PWSPD_F43",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": { "limit": "7200", "method": "linear", "limit_area": "None" }

--- a/data/dspec/Magnolia/48/magnolia_transform_48.json
+++ b/data/dspec/Magnolia/48/magnolia_transform_48.json
@@ -46,7 +46,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "PL_WNDIR_F48",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {
@@ -65,7 +65,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "PL_WNDSPD_F48",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_12h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WSPD_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WDIR_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_24h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WSPD_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WDIR_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_48h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Aransas/ar_mlp_surge_72h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_12h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WSPD_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WDIR_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_24h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WSPD_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WDIR_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_48h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/North_Jetty/nj_mlp_surge_72h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_12h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WSPD_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WDIR_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_24h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WSPD_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WDIR_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_48h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Port_Isabel/pi_mlp_surge_72h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_12h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WSPD_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "WDIR_FUTR_12",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_24h_pred.json
@@ -111,7 +111,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WSPD_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -122,7 +122,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "WDIR_FUTR_24",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_48h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_48",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
+++ b/data/dspec/Surge/Rockport/rp_mlp_surge_72h_pred.json
@@ -119,7 +119,7 @@
                 }
             },
             "outKey": "WSPD_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         },
         {
             "_name": "wind direction future",
@@ -138,7 +138,7 @@
                 }
             },
             "outKey": "WDIR_FUTR_72",
-            "stalenessOffset": 43200
+            "stalenessOffset": 45000
         }
     ],
     "postProcessCall": [

--- a/data/dspec/VirginiaKey/12hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/12hr_VirginiaKey_wl_Estrada.json
@@ -58,7 +58,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "VK_PWSPD_F12",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -77,7 +77,7 @@
             "interval": 3600,
             "range": [12, 1],
             "outKey": "VK_PWDIR_F12",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/24hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/24hr_VirginiaKey_wl_Estrada.json
@@ -59,7 +59,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "VK_PWSPD_F24",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -78,7 +78,7 @@
             "interval": 3600,
             "range": [24, 1],
             "outKey": "VK_PWDIR_F24",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/48hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/48hr_VirginiaKey_wl_Estrada.json
@@ -59,7 +59,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "VK_PWSPD_F48",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -78,7 +78,7 @@
             "interval": 3600,
             "range": [48, 1],
             "outKey": "VK_PWDIR_F48",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/72hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/72hr_VirginiaKey_wl_Estrada.json
@@ -59,7 +59,7 @@
             "interval": 3600,
             "range": [72, 1],
             "outKey": "VK_PWSPD_F72",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -78,7 +78,7 @@
             "interval": 3600,
             "range": [72, 1],
             "outKey": "VK_PWDIR_F72",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {

--- a/data/dspec/VirginiaKey/96hr_VirginiaKey_wl_Estrada.json
+++ b/data/dspec/VirginiaKey/96hr_VirginiaKey_wl_Estrada.json
@@ -59,7 +59,7 @@
             "interval": 3600,
             "range": [96, 1],
             "outKey": "VK_PWSPD_F96",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
 			"dataIntegrityCall": {
                 "call": "PandasInterpolation",
                 "args": {
@@ -78,7 +78,7 @@
             "interval": 3600,
             "range": [96, 1],
             "outKey": "VK_PWDIR_F96",
-            "stalenessOffset": 43200,
+            "stalenessOffset": 45000,
             "dataIntegrityCall": {
                 "call": "AngleInterpolation",
                 "args": {


### PR DESCRIPTION
Addressing the remaining staleness errors for NDFD by increasing the staleness offset from 12 hours to 12 hours and 30 minutes to capture any remaining staleness errors. We've seen a a few staleness errors at times around 12 hours and 14 minutes and anticipate that when the cold stunning season starts we'll see less of these issues but why not increase to encapsulate all since we usually trust NDFD data anyway. 

To Test Run Some models with NDFD: 
- `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/Bird-Island_Water-Temperature_3hr.json`
- `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/ColdStunning/MRE_Bird-Island_Water-Temperature_3hr.json`
- `docker exec semaphore-core python3 src/semaphoreRunner.py -d ./data/dspec/CRPS/CRPS_3hr.json`