### PR TITLE
984 new statistics end point for requesting specific time range

### DIFF
--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -174,6 +174,8 @@ async def get_output_statistics_range(modelNames: list[str] = Query(None), fromD
     Queries output statistics for given models in a specefic range of time.
      Args:
         - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
+        - `fromDateTime` (string): "YYYYMMDDHH" UTC Date to start at. Ex. 2024010100 for Jan 1, 2024 at 00:00 UTC
+        - `toDateTime` (string): "YYYYMMDDHH" UTC Date to end at. Ex. 2024010200 for Jan 2, 2024 at 00:00 UTC
     Returns:
     - A list of dictionaries containing these statistics for each model:
         model name, time generated, percentile values (p1-p99),
@@ -458,11 +460,7 @@ def serialize_statistics(statistics_results: list[dict] | None, requested_model_
     for stats in statistics_results:
         serialized = {
             "modelName": stats["modelName"],
-            "timeGenerated": jsonable_encoder(
-                stats["timeGenerated"].replace(tzinfo=None)
-                if stats.get("timeGenerated") is not None
-                else None
-            ),
+            "timeGenerated": jsonable_encoder(stats['timeGenerated'].replace(tzinfo=None) if stats.get('timeGenerated') is not None else None ),
             'p1': stats['p1'],
             'p5': stats['p5'],
             'p10': stats['p10'],

--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -190,7 +190,7 @@ async def get_output_statistics_range(modelNames: list[str] = Query(None), fromD
 
     statistics_results = (statistics_class.retrieve_statistics(modelNames, fromDateTime=fromDateTime, toDateTime=toDateTime))
 
-    return serialize_statistics_range( statistics_results, modelNames)
+    return serialize_statistics( statistics_results, modelNames, ranged=True)
 
 @app.get('/output_time_span/')
 async def get_outputs_time_span(fromDateTime: str, toDateTime: str, modelNames: list[str] = Query(None)):
@@ -427,10 +427,16 @@ def serialize_output_series(series: Series) -> dict[any]:
     serialized['_Series__data'] = serialized_data # Add it back to the response
     return serialized
 
-def serialize_statistics(statistics_results: list[dict] | None, requested_model_names: list[str]) -> dict:
+def serialize_statistics(statistics_results: list[dict] | None, requested_model_names: list[str], ranged: bool = False) -> dict:
     """
     Serializes statistics results so that every requested model name
     is included in the response, even if no statistics exist for it.
+
+    If ranged=False (default):
+        Returns one statistics dictionary per model.
+
+    If ranged=True:
+        Returns a list of statistics dictionaries per model.
     """
 
     if statistics_results is None:
@@ -438,14 +444,25 @@ def serialize_statistics(statistics_results: list[dict] | None, requested_model_
             model_name: None
             for model_name in requested_model_names
         }
-
+    
     # Build lookup table
-    statistics_by_model = {}
+    if ranged:
+        statistics_by_model = {
+            model_name: []
+            for model_name in requested_model_names
+        }
+    else:
+        statistics_by_model = {}
+
 
     for stats in statistics_results:
-        statistics_by_model[stats['modelName']] = {
-            'modelName': stats['modelName'],
-            'timeGenerated': jsonable_encoder(stats['timeGenerated'].replace(tzinfo=None) if stats.get('timeGenerated') is not None else None ),
+        serialized = {
+            "modelName": stats["modelName"],
+            "timeGenerated": jsonable_encoder(
+                stats["timeGenerated"].replace(tzinfo=None)
+                if stats.get("timeGenerated") is not None
+                else None
+            ),
             'p1': stats['p1'],
             'p5': stats['p5'],
             'p10': stats['p10'],
@@ -461,65 +478,23 @@ def serialize_statistics(statistics_results: list[dict] | None, requested_model_
             'std_dev': stats['std_dev']
         }
 
+        if ranged:
+            statistics_by_model[stats["modelName"]].append(serialized)
+        else:
+            statistics_by_model[stats["modelName"]] = serialized
+
     # Ensure all requested models exist
     serialized_results = {}
 
     for model_name in requested_model_names:
-        serialized_results[model_name] = (statistics_by_model.get(model_name))
-    return serialized_results
-
-def serialize_statistics_range(statistics_results: list[dict] | None, requested_model_names: list[str]) -> dict:
-    """
-    Serializes statistics results for a time range so that every requested
-    model name is included in the response, even if no statistics exist for it.
-
-    Each model name maps to a list of statistics ordered by timeGenerated.
-    """
-
-    if statistics_results is None:
-        return {
-            model_name: None
-            for model_name in requested_model_names
-        }
-
-    # Initialize lookup table
-    statistics_by_model = {
-        model_name: []
-        for model_name in requested_model_names
-    }
-
-    for stats in statistics_results:
-        statistics_by_model.setdefault(stats["modelName"], []).append({
-            "modelName": stats["modelName"],
-            "timeGenerated": jsonable_encoder(
-                stats["timeGenerated"].replace(tzinfo=None)
-                if stats.get("timeGenerated") is not None
+        if ranged:
+            serialized_results[model_name] = (
+                statistics_by_model[model_name]
+                if statistics_by_model[model_name]
                 else None
-            ),
-            "p1": stats["p1"],
-            "p5": stats["p5"],
-            "p10": stats["p10"],
-            "p25": stats["p25"],
-            "p50": stats["p50"],
-            "p75": stats["p75"],
-            "p90": stats["p90"],
-            "p95": stats["p95"],
-            "p99": stats["p99"],
-            "min": stats["min"],
-            "max": stats["max"],
-            "mean": stats["mean"],
-            "std_dev": stats["std_dev"],
-        })
-
-    # Ensure all requested models exist
-    serialized_results = {}
-
-    for model_name in requested_model_names:
-        serialized_results[model_name] = (
-            statistics_by_model[model_name]
-            if statistics_by_model[model_name]
-            else None
-        )
+            )
+        else:
+            serialized_results[model_name] = statistics_by_model.get(model_name)
 
     return serialized_results
 #endregion

--- a/src/API/apiDriver.py
+++ b/src/API/apiDriver.py
@@ -168,6 +168,30 @@ async def get_output_statistics(modelNames: list[str] = Query(None)):
 
     return serialize_statistics( statistics_results, modelNames)
 
+@app.get('/select_output_statistics_range/')
+async def get_output_statistics_range(modelNames: list[str] = Query(None), fromDateTime: str = Query(None), toDateTime: str = Query(None)):
+    """
+    Queries output statistics for given models in a specefic range of time.
+     Args:
+        - `modelNames` (string): The name of the model (e.g. "test AI"), you can repeat this parameter to request multiple models
+    Returns:
+    - A list of dictionaries containing these statistics for each model:
+        model name, time generated, percentile values (p1-p99),
+        minimum, maximum, mean, and standard deviation.
+
+    """
+    if not modelNames:
+        raise HTTPException(
+            status_code=422,
+            detail='No model names were provided'
+        )
+
+    statistics_class = Statistics()
+
+    statistics_results = (statistics_class.retrieve_statistics(modelNames, fromDateTime=fromDateTime, toDateTime=toDateTime))
+
+    return serialize_statistics_range( statistics_results, modelNames)
+
 @app.get('/output_time_span/')
 async def get_outputs_time_span(fromDateTime: str, toDateTime: str, modelNames: list[str] = Query(None)):
     """
@@ -442,5 +466,60 @@ def serialize_statistics(statistics_results: list[dict] | None, requested_model_
 
     for model_name in requested_model_names:
         serialized_results[model_name] = (statistics_by_model.get(model_name))
+    return serialized_results
+
+def serialize_statistics_range(statistics_results: list[dict] | None, requested_model_names: list[str]) -> dict:
+    """
+    Serializes statistics results for a time range so that every requested
+    model name is included in the response, even if no statistics exist for it.
+
+    Each model name maps to a list of statistics ordered by timeGenerated.
+    """
+
+    if statistics_results is None:
+        return {
+            model_name: None
+            for model_name in requested_model_names
+        }
+
+    # Initialize lookup table
+    statistics_by_model = {
+        model_name: []
+        for model_name in requested_model_names
+    }
+
+    for stats in statistics_results:
+        statistics_by_model.setdefault(stats["modelName"], []).append({
+            "modelName": stats["modelName"],
+            "timeGenerated": jsonable_encoder(
+                stats["timeGenerated"].replace(tzinfo=None)
+                if stats.get("timeGenerated") is not None
+                else None
+            ),
+            "p1": stats["p1"],
+            "p5": stats["p5"],
+            "p10": stats["p10"],
+            "p25": stats["p25"],
+            "p50": stats["p50"],
+            "p75": stats["p75"],
+            "p90": stats["p90"],
+            "p95": stats["p95"],
+            "p99": stats["p99"],
+            "min": stats["min"],
+            "max": stats["max"],
+            "mean": stats["mean"],
+            "std_dev": stats["std_dev"],
+        })
+
+    # Ensure all requested models exist
+    serialized_results = {}
+
+    for model_name in requested_model_names:
+        serialized_results[model_name] = (
+            statistics_by_model[model_name]
+            if statistics_by_model[model_name]
+            else None
+        )
+
     return serialized_results
 #endregion

--- a/src/ModelExecution/statistics.py
+++ b/src/ModelExecution/statistics.py
@@ -13,7 +13,8 @@ a given dataset.
 #----------------------------------
 import numpy as np
 from SeriesStorage.ISeriesStorage import series_storage_factory
-from DataClasses import Series
+from DataClasses import Series, TimeDescription
+from datetime import datetime
 
 
 class Statistics:
@@ -74,11 +75,19 @@ class Statistics:
 
         return statistics
     
-    def retrieve_statistics(self, model_names: list[str]) -> list[dict] | None:
+    def retrieve_statistics(self, model_names: list[str], fromDateTime: str = None, toDateTime: str = None) -> list[dict] | None:
         '''
             Retrieve statistics for the list of models passed.
         
         '''
+        print(f"==============Retrieving statistics for models: {model_names} from {fromDateTime} to {toDateTime}=============")
+        from datetime import datetime
+
+        fromDateTime = datetime.strptime(fromDateTime, "%Y%m%d%H")
+        toDateTime = datetime.strptime(toDateTime, "%Y%m%d%H")
         self.seriesStorage = series_storage_factory()
+        if fromDateTime is not None and toDateTime is not None:
+            return self.seriesStorage.select_output_statistics_range(model_names, fromDateTime, toDateTime)
+        
         return self.seriesStorage.select_latest_output_statistics(model_names)
 

--- a/src/ModelExecution/statistics.py
+++ b/src/ModelExecution/statistics.py
@@ -80,13 +80,12 @@ class Statistics:
             Retrieve statistics for the list of models passed.
         
         '''
-        print(f"==============Retrieving statistics for models: {model_names} from {fromDateTime} to {toDateTime}=============")
-        from datetime import datetime
 
-        fromDateTime = datetime.strptime(fromDateTime, "%Y%m%d%H")
-        toDateTime = datetime.strptime(toDateTime, "%Y%m%d%H")
         self.seriesStorage = series_storage_factory()
+
         if fromDateTime is not None and toDateTime is not None:
+            fromDateTime = datetime.strptime(fromDateTime, "%Y%m%d%H")
+            toDateTime = datetime.strptime(toDateTime, "%Y%m%d%H")
             return self.seriesStorage.select_output_statistics_range(model_names, fromDateTime, toDateTime)
         
         return self.seriesStorage.select_latest_output_statistics(model_names)

--- a/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
+++ b/src/SeriesStorage/SS_Classes/SQLAlchemyORM_Postgres.py
@@ -346,7 +346,99 @@ class SQLAlchemyORM_Postgres(ISeriesStorage):
             results.append(series)
         return results
     
-    
+    def select_output_statistics_range(self, model_names: list[str], fromDateTime: datetime, toDateTime: datetime) -> list[dict] | None:
+        '''
+        This function returns the statistics for each model in the provided list of model names
+        whose generation time falls within the specified time range, or None if no matching
+        statistics are found.
+
+        :param model_names: list[str] - A list of model names to query for.
+        :param fromDateTime: datetime - The inclusive start of the time range (UTC).
+        :param toDateTime: datetime - The inclusive end of the time range (UTC).
+
+        :returns list[dict] | None - A list of dictionaries where each dictionary contains
+            the statistics for a model, or None if no statistics are found. Each dictionary
+            has the following format:
+            {
+                'modelName': str,
+                'timeGenerated': timestamp in UTC,
+                'p1': float,
+                'p5': float,
+                'p10': float,
+                'p25': float,
+                'p50': float,
+                'p75': float,
+                'p90': float,
+                'p95': float,
+                'p99': float,
+                'min': float,
+                'max': float,
+                'mean': float,
+                'std_dev': float
+            }
+        '''
+        stmt = text("""
+        SELECT
+            o."modelName",
+            o."timeGenerated",
+            s."p1",
+            s."p5",
+            s."p10",
+            s."p25",
+            s."p50",
+            s."p75",
+            s."p90",
+            s."p95",
+            s."p99",
+            s."min",
+            s."max",
+            s."mean",
+            s."std_dev"
+        FROM outputs AS o
+        INNER JOIN output_statistics AS s
+            ON s."outputID" = o."id"
+        WHERE o."modelName" IN :model_names
+        AND o."timeGenerated" >= :fromDateTime
+        AND o."timeGenerated" <= :toDateTime
+        ORDER BY o."modelName", o."timeGenerated" DESC
+        """)
+
+        stmt = stmt.bindparams(
+            bindparam("model_names", value=tuple(model_names), expanding=True, type_=String),
+            bindparam("fromDateTime", value=fromDateTime),
+            bindparam("toDateTime", value=toDateTime),
+        )
+
+        result = self.__dbSelection(stmt).fetchall()
+        
+        if not result:
+            return None
+        
+        # splice the results into dictionaries
+        statistics_results = []
+        for row in result:
+            statistics_dict = {
+                'modelName': row[0],
+                'timeGenerated': row[1].replace(tzinfo=timezone.utc),
+                'p1': row[2],
+                'p5': row[3],
+                'p10': row[4],
+                'p25': row[5],
+                'p50': row[6],
+                'p75': row[7],
+                'p90': row[8],
+                'p95': row[9],
+                'p99': row[10],
+                'min': row[11],
+                'max': row[12],
+                'mean': row[13],
+                'std_dev': row[14]
+            }
+            statistics_results.append(statistics_dict)
+        
+        return statistics_results
+        
+            
     def select_latest_output_statistics(self, model_names: list[str]) -> list[dict] | None:
         '''
         This function returns the latest statistics for each model in the list of model names, or None

--- a/src/tests/UnitTests/test_unit_api.py
+++ b/src/tests/UnitTests/test_unit_api.py
@@ -13,9 +13,9 @@ docker exec semaphore-core python3 -m pytest src/tests/UnitTests/test_unit_api.p
 import numpy as np
 import pandas as pd
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from DataClasses import Series, SemaphoreSeriesDescription
-from src.API.apiDriver import serialize_output_series
+from src.API.apiDriver import serialize_output_series, serialize_statistics
 
 @pytest.mark.parametrize(
     "data_array",
@@ -263,3 +263,178 @@ def test_serialize_output_multiple_rows():
         assert result['_Series__data'][idx]['leadTime'] == 367200
         assert result['_Series__data'][idx]['timeGenerated'] == "2026-01-01T00:00:00"
 
+@pytest.mark.parametrize(
+    "ranged, statistics_results, requested_model_names, expected_result",
+    [
+        # Single result per model
+        (
+            False,
+            [
+                {
+                    "modelName": "ModelA",
+                    "timeGenerated": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    "p1": 1.0,
+                    "p5": 2.0,
+                    "p10": 3.0,
+                    "p25": 4.0,
+                    "p50": 5.0,
+                    "p75": 6.0,
+                    "p90": 7.0,
+                    "p95": 8.0,
+                    "p99": 9.0,
+                    "min": 10.0,
+                    "max": 11.0,
+                    "mean": 12.0,
+                    "std_dev": 13.0,
+                },
+                {
+                    "modelName": "ModelB",
+                    "timeGenerated": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    "p1": 2.0,
+                    "p5": 4.0,
+                    "p10": 6.0,
+                    "p25": 8.0,
+                    "p50": 10.0,
+                    "p75": 12.0,
+                    "p90": 14.0,
+                    "p95": 16.0,
+                    "p99": 18.0,
+                    "min": 20.0,
+                    "max": 22.0,
+                    "mean": 24.0,
+                    "std_dev": 26.0,
+                },
+            ],
+            ["ModelA", "ModelB"],
+            {
+                "ModelA": {
+                    "modelName": "ModelA",
+                    "timeGenerated": "2026-01-01T00:00:00",
+                    "p1": 1.0,
+                    "p5": 2.0,
+                    "p10": 3.0,
+                    "p25": 4.0,
+                    "p50": 5.0,
+                    "p75": 6.0,
+                    "p90": 7.0,
+                    "p95": 8.0,
+                    "p99": 9.0,
+                    "min": 10.0,
+                    "max": 11.0,
+                    "mean": 12.0,
+                    "std_dev": 13.0,
+                },
+                "ModelB": {
+                    "modelName": "ModelB",
+                    "timeGenerated": "2026-01-02T00:00:00",
+                    "p1": 2.0,
+                    "p5": 4.0,
+                    "p10": 6.0,
+                    "p25": 8.0,
+                    "p50": 10.0,
+                    "p75": 12.0,
+                    "p90": 14.0,
+                    "p95": 16.0,
+                    "p99": 18.0,
+                    "min": 20.0,
+                    "max": 22.0,
+                    "mean": 24.0,
+                    "std_dev": 26.0,
+                },
+            },
+        ),
+
+        # Multiple results per model
+        (
+            True,
+            [
+                {
+                    "modelName": "ModelA",
+                    "timeGenerated": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    "p1": 1.0,
+                    "p5": 2.0,
+                    "p10": 3.0,
+                    "p25": 4.0,
+                    "p50": 5.0,
+                    "p75": 6.0,
+                    "p90": 7.0,
+                    "p95": 8.0,
+                    "p99": 9.0,
+                    "min": 10.0,
+                    "max": 11.0,
+                    "mean": 12.0,
+                    "std_dev": 13.0,
+                },
+                {
+                    "modelName": "ModelA",
+                    "timeGenerated": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    "p1": 2.0,
+                    "p5": 4.0,
+                    "p10": 6.0,
+                    "p25": 8.0,
+                    "p50": 10.0,
+                    "p75": 12.0,
+                    "p90": 14.0,
+                    "p95": 16.0,
+                    "p99": 18.0,
+                    "min": 20.0,
+                    "max": 22.0,
+                    "mean": 24.0,
+                    "std_dev": 26.0,
+                },
+            ],
+            ["ModelA"],
+            {
+                "ModelA": [
+                    {
+                        "modelName": "ModelA",
+                        "timeGenerated": "2026-01-01T00:00:00",
+                        "p1": 1.0,
+                        "p5": 2.0,
+                        "p10": 3.0,
+                        "p25": 4.0,
+                        "p50": 5.0,
+                        "p75": 6.0,
+                        "p90": 7.0,
+                        "p95": 8.0,
+                        "p99": 9.0,
+                        "min": 10.0,
+                        "max": 11.0,
+                        "mean": 12.0,
+                        "std_dev": 13.0,
+                    },
+                    {
+                        "modelName": "ModelA",
+                        "timeGenerated": "2026-01-02T00:00:00",
+                        "p1": 2.0,
+                        "p5": 4.0,
+                        "p10": 6.0,
+                        "p25": 8.0,
+                        "p50": 10.0,
+                        "p75": 12.0,
+                        "p90": 14.0,
+                        "p95": 16.0,
+                        "p99": 18.0,
+                        "min": 20.0,
+                        "max": 22.0,
+                        "mean": 24.0,
+                        "std_dev": 26.0,
+                    },
+                ]
+            },
+        ),
+    ],
+    ids=["single", "ranged"],
+)
+def test_serialize_statistics(ranged,statistics_results,requested_model_names, expected_result,):
+    """
+    Verify that statistics are serialized into the format returned by the API.
+    """
+
+    result = serialize_statistics(
+        statistics_results,
+        requested_model_names,
+        ranged=ranged,
+    )
+
+    assert result == expected_result

--- a/src/tests/UnitTests/test_unit_sqlAlchemy.py
+++ b/src/tests/UnitTests/test_unit_sqlAlchemy.py
@@ -654,10 +654,8 @@ def test_select_latest_output_statistics(test_data, expected_result):
         (
             # test tuples that would be returned from the DB query
             [
-                # ( "ModelA", datetime(2026, 1, 1, 0, 0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0),
                 ( "ModelB", datetime(2026, 1, 2, 0, 0), 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0),
                 ( "ModelC", datetime(2026, 1, 3, 0, 0), 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0),
-                # ( "ModelD", datetime(2026, 1, 4, 0, 0), 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0, 52.0),
             ],
             # the expected output after parsing the DB results
             [
@@ -724,7 +722,6 @@ def test_select_output_statistics_range(test_specific_data, test_expected_result
 
         with patch.object(storage, '_SQLAlchemyORM_Postgres__dbSelection', return_value=mock_results):
             result = storage.select_output_statistics_range([ 'ModelB','ModelC'], datetime(2026, 1, 2, 0, 0), datetime(2026, 1, 3, 0, 0))
-        print(f'==========================Result=============================-: \n{result}')
         # ensure the tuple splicing matches the expected result
         assert len(result) == len(test_expected_result)
         assert result == test_expected_result

--- a/src/tests/UnitTests/test_unit_sqlAlchemy.py
+++ b/src/tests/UnitTests/test_unit_sqlAlchemy.py
@@ -646,6 +646,7 @@ def test_select_latest_output_statistics(test_data, expected_result):
         # ensure the tuple splicing matches the expected result
         assert len(result) == len(expected_result)
         assert result == expected_result
+        
 @pytest.mark.parametrize(
     "test_specific_data, test_expected_result",
     [
@@ -653,10 +654,10 @@ def test_select_latest_output_statistics(test_data, expected_result):
         (
             # test tuples that would be returned from the DB query
             [
-                ( "ModelA", datetime(2026, 1, 1, 0, 0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0),
+                # ( "ModelA", datetime(2026, 1, 1, 0, 0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0),
                 ( "ModelB", datetime(2026, 1, 2, 0, 0), 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0),
                 ( "ModelC", datetime(2026, 1, 3, 0, 0), 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0),
-                ( "ModelD", datetime(2026, 1, 4, 0, 0), 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0, 52.0),
+                # ( "ModelD", datetime(2026, 1, 4, 0, 0), 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0, 52.0),
             ],
             # the expected output after parsing the DB results
             [
@@ -722,7 +723,7 @@ def test_select_output_statistics_range(test_specific_data, test_expected_result
         mock_results.fetchall.return_value = test_specific_data
 
         with patch.object(storage, '_SQLAlchemyORM_Postgres__dbSelection', return_value=mock_results):
-            result = storage.select_output_statistics_range(['ModelA', 'ModelB','ModelC','ModelD'], datetime(2026, 1, 2, 0, 0), datetime(2026, 1, 3, 0, 0))
+            result = storage.select_output_statistics_range([ 'ModelB','ModelC'], datetime(2026, 1, 2, 0, 0), datetime(2026, 1, 3, 0, 0))
         print(f'==========================Result=============================-: \n{result}')
         # ensure the tuple splicing matches the expected result
         assert len(result) == len(test_expected_result)

--- a/src/tests/UnitTests/test_unit_sqlAlchemy.py
+++ b/src/tests/UnitTests/test_unit_sqlAlchemy.py
@@ -646,3 +646,84 @@ def test_select_latest_output_statistics(test_data, expected_result):
         # ensure the tuple splicing matches the expected result
         assert len(result) == len(expected_result)
         assert result == expected_result
+@pytest.mark.parametrize(
+    "test_specific_data, test_expected_result",
+    [
+        # Test case 1: Test with multiple models within 
+        (
+            # test tuples that would be returned from the DB query
+            [
+                ( "ModelA", datetime(2026, 1, 1, 0, 0), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0),
+                ( "ModelB", datetime(2026, 1, 2, 0, 0), 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0),
+                ( "ModelC", datetime(2026, 1, 3, 0, 0), 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0, 30.0, 33.0, 36.0, 39.0),
+                ( "ModelD", datetime(2026, 1, 4, 0, 0), 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0, 52.0),
+            ],
+            # the expected output after parsing the DB results
+            [
+            
+                {
+                    'modelName': "ModelB",
+                    'timeGenerated': datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc), # the result should be timezone aware and in UTC
+                    'p1': 2.0,
+                    'p5': 4.0,
+                    'p10': 6.0,
+                    'p25': 8.0,
+                    'p50': 10.0,
+                    'p75': 12.0,
+                    'p90': 14.0,
+                    'p95': 16.0,
+                    'p99': 18.0,
+                    'min': 20.0,
+                    'max': 22.0,
+                    'mean': 24.0,
+                    'std_dev': 26.0
+                },
+                {
+                    'modelName': "ModelC",
+                    'timeGenerated': datetime(2026, 1, 3, 0, 0, tzinfo=timezone.utc), # the result should be timezone aware and in UTC
+                    'p1': 3.0,
+                    'p5': 6.0,
+                    'p10': 9.0,
+                    'p25': 12.0,
+                    'p50': 15.0,
+                    'p75': 18.0,
+                    'p90': 21.0,
+                    'p95': 24.0,
+                    'p99': 27.0,
+                    'min': 30.0,
+                    'max': 33.0,
+                    'mean': 36.0,
+                    'std_dev': 39.0
+                }
+
+            ]
+        )
+    ],
+    ids=["ModelsWithinRange"]
+)
+
+def test_select_output_statistics_range(test_specific_data, test_expected_result):
+    '''
+    This test checks that the tuple splicing in select_output_statistics_range
+    correctly parses the DB results into the expected dictionary format
+
+    When requesting a model that does not compute statistics, no dictionary should be returned
+    for that model in the dictionary list.
+
+    docker exec semaphore-core python3 -m pytest src/tests/UnitTests/test_unit_sqlAlchemy.py::test_select_output_statistics_range -s
+    '''
+
+    # skip the db connection by replacing the __init__ method
+    with patch.object(SQLAlchemyORM_Postgres, '__init__', lambda x: None):
+        storage = SQLAlchemyORM_Postgres()
+
+        # force the __dbSelection method to return our test data instead of querying the DB
+        mock_results = MagicMock()
+        mock_results.fetchall.return_value = test_specific_data
+
+        with patch.object(storage, '_SQLAlchemyORM_Postgres__dbSelection', return_value=mock_results):
+            result = storage.select_output_statistics_range(['ModelA', 'ModelB','ModelC','ModelD'], datetime(2026, 1, 2, 0, 0), datetime(2026, 1, 3, 0, 0))
+        print(f'==========================Result=============================-: \n{result}')
+        # ensure the tuple splicing matches the expected result
+        assert len(result) == len(test_expected_result)
+        assert result == test_expected_result


### PR DESCRIPTION
# Why?
We wanted to be able to request statistics within a specific time range

# How Do I Test?
I added 2 new tests to verify it works.
- docker compose up -d --build
- docker exec semaphore-core python -m pytest -s


If you populate the db and pull data using the api the result should look like this:
<img width="465" height="503" alt="Screenshot 2026-07-20 190906" src="https://github.com/user-attachments/assets/7cd0fe33-4ea4-4a39-95e5-9b917ee239c6" />
