### PR TITLE
create dspecs for ESB model

### DIFF
--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_102hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_102hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_102hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_102hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 367200,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                108,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_108",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_108",
+            "dType": "float",
+            "indexes": [
+                0,
+                107
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_108hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_108hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_108hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_108hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 388800,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                114,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_114",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_114",
+            "dType": "float",
+            "indexes": [
+                0,
+                113
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_114hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_114hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_114hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_114hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 410400,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                120,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_120",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_120",
+            "dType": "float",
+            "indexes": [
+                0,
+                119
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_120hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_120hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_120hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_120hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 432000,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                126,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_126",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_126",
+            "dType": "float",
+            "indexes": [
+                0,
+                125
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_12hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_12hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_12hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_12hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 43200,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                18,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_18",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_18",
+            "dType": "float",
+            "indexes": [
+                0,
+                17
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_18hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_18hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_18hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_18hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 64800,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                24,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_24",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_24",
+            "dType": "float",
+            "indexes": [
+                0,
+                23
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_24hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_24hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_24hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_24hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 86400,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                30,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_30",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_30",
+            "dType": "float",
+            "indexes": [
+                0,
+                29
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_30hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_30hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_30hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_30hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 108000,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                36,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_36",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_36",
+            "dType": "float",
+            "indexes": [
+                0,
+                35
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_36hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_36hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_36hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_36hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 129600,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                42,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_42",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_42",
+            "dType": "float",
+            "indexes": [
+                0,
+                41
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
@@ -211,7 +211,7 @@
             "call": "ComputeMean",
             "args": {
                 "dropOutlierSeries": true,
-                "thresholdDeviationFromMean": 3.5,
+                "thresholdDeviationFromMedian": 3.5,
                 "sentinel_value": 10000,
                 "targetSeries": [
                     "Aransas-Wildlife-Refuge_water-temp_25",

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
@@ -1,0 +1,231 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_3hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_3hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1200,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 10800,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+         {
+            "_name": "Water Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },        
+        {
+            "_name": "Water Temp_PO",
+            "location": "PortOconnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },       
+        {
+            "_name": "Water Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },       
+        {
+            "_name": "Air Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EsperituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                9,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_9",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "processMissingValues": "dropSeries",
+                "dropOutlierSeries": false,
+                "targetSeries": [
+                    "Air_Temp_AWR",
+                    "Air_Temp_PO",
+                    "Air_Temp_SD",
+                    "Air_Temp_PL"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"    
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "processMissingValues": "dropSeries",
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMean": 3.5,
+                "targetSeries": [
+                    "Water_Temp_AWR",
+                    "Water_Temp_PO",
+                    "Water_Temp_SD",
+                    "Water_Temp_PL"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"    
+            }
+        }
+    ],
+    "vectorOrder": [
+        { "key": "Espiritu-Santo-Bay_water-temp_25"       , "dType": "float", "indexes": [2, 26] },
+        { "key": "Espiritu-Santo-Bay_air-temp_25"         , "dType": "float", "indexes": [2, 26] },
+        { "key": "Espiritu-Santo-Bay_predicted_air-temp_9", "dType": "float", "indexes": [0, 2] }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
@@ -196,8 +196,8 @@
         {
             "call": "ComputeMean",
             "args": {
-                "processMissingValues": "dropSeries",
                 "dropOutlierSeries": false,
+                "sentinel_value": 10000,                
                 "targetSeries": [
                     "Aransas-Wildlife-Refuge_air-temp_25",
                     "Port-OConnor_air-temp_25",
@@ -210,9 +210,9 @@
         {
             "call": "ComputeMean",
             "args": {
-                "processMissingValues": "dropSeries",
                 "dropOutlierSeries": true,
                 "thresholdDeviationFromMean": 3.5,
+                "sentinel_value": 10000,
                 "targetSeries": [
                     "Aransas-Wildlife-Refuge_water-temp_25",
                     "Port-OConnor_water-temp_25",

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
@@ -37,7 +37,7 @@
             }
         },
          {
-            "_name": "Water Temp_SD",
+            "_name": "Water_Temp_SD",
             "location": "Seadrift",
             "source": "LIGHTHOUSE",
             "series": "dWaterTmp",
@@ -56,8 +56,8 @@
             }
         },        
         {
-            "_name": "Water Temp_PO",
-            "location": "PortOconnor",
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
             "source": "LIGHTHOUSE",
             "series": "dWaterTmp",
             "unit": "celsius",
@@ -75,7 +75,7 @@
             }
         },       
         {
-            "_name": "Water Temp_AWR",
+            "_name": "Water_Temp_AWR",
             "location": "AransasWildlifeRefuge",
             "source": "LIGHTHOUSE",
             "series": "dWaterTmp",
@@ -94,7 +94,7 @@
             }
         },       
         {
-            "_name": "Air Temp_PL",
+            "_name": "Air_Temp_PL",
             "location": "PortLavaca",
             "source": "LIGHTHOUSE",
             "series": "dAirTmp",
@@ -113,7 +113,7 @@
             }
         },
         {
-            "_name": "Air Temp_SD",
+            "_name": "Air_Temp_SD",
             "location": "Seadrift",
             "source": "LIGHTHOUSE",
             "series": "dAirTmp",
@@ -132,7 +132,7 @@
             }
         },
         {
-            "_name": "Air Temp_PO",
+            "_name": "Air_Temp_PO",
             "location": "PortOConnor",
             "source": "LIGHTHOUSE",
             "series": "dAirTmp",
@@ -171,7 +171,7 @@
         },
         {
             "_name": "Predicted Air Temp",
-            "location": "EsperituSantoBay",
+            "location": "EspirituSantoBay",
             "source": "NDFD_JSON",
             "series": "pAirTemp",
             "unit": "celsius",
@@ -199,10 +199,10 @@
                 "processMissingValues": "dropSeries",
                 "dropOutlierSeries": false,
                 "targetSeries": [
-                    "Air_Temp_AWR",
-                    "Air_Temp_PO",
-                    "Air_Temp_SD",
-                    "Air_Temp_PL"
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
                 ],
                 "outKey": "Espiritu-Santo-Bay_air-temp_25"    
             }
@@ -214,10 +214,10 @@
                 "dropOutlierSeries": true,
                 "thresholdDeviationFromMean": 3.5,
                 "targetSeries": [
-                    "Water_Temp_AWR",
-                    "Water_Temp_PO",
-                    "Water_Temp_SD",
-                    "Water_Temp_PL"
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
                 ],
                 "outKey": "Espiritu-Santo-Bay_water-temp_25"    
             }

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_3hr.json
@@ -6,7 +6,7 @@
     "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_3hr",
     "timingInfo": {
         "active": true,
-        "offset": 1200,
+        "offset": 1500,
         "interval": 3600
     },
     "outputInfo": {
@@ -226,6 +226,6 @@
     "vectorOrder": [
         { "key": "Espiritu-Santo-Bay_water-temp_25"       , "dType": "float", "indexes": [2, 26] },
         { "key": "Espiritu-Santo-Bay_air-temp_25"         , "dType": "float", "indexes": [2, 26] },
-        { "key": "Espiritu-Santo-Bay_predicted_air-temp_9", "dType": "float", "indexes": [0, 2] }
+        { "key": "Espiritu-Santo-Bay_predicted_air-temp_9", "dType": "float", "indexes": [0, 8] }
     ]
 }

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_42hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_42hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_42hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_42hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 151200,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                48,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_48",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_48",
+            "dType": "float",
+            "indexes": [
+                0,
+                47
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_48hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_48hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_48hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_48hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 172800,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                54,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_54",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_54",
+            "dType": "float",
+            "indexes": [
+                0,
+                53
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_54hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_54hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_54hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_54hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 194400,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                60,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_60",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_60",
+            "dType": "float",
+            "indexes": [
+                0,
+                59
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_60hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_60hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_60hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_60hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 216000,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                66,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_66",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_66",
+            "dType": "float",
+            "indexes": [
+                0,
+                65
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_66hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_66hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_66hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_66hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 237600,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                72,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_72",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_72",
+            "dType": "float",
+            "indexes": [
+                0,
+                71
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_6hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_6hr.json
@@ -1,0 +1,231 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_6hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_6hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 21600,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+         {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                12,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_12",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        { "key": "Espiritu-Santo-Bay_water-temp_25"        , "dType": "float", "indexes": [2, 26] },
+        { "key": "Espiritu-Santo-Bay_air-temp_25"          , "dType": "float", "indexes": [2, 26] },
+        { "key": "Espiritu-Santo-Bay_predicted_air-temp_12", "dType": "float", "indexes": [0, 11] }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_72hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_72hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_72hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_72hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 259200,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                78,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_78",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_78",
+            "dType": "float",
+            "indexes": [
+                0,
+                77
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_78hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_78hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_78hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_78hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 280800,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                84,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_84",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_84",
+            "dType": "float",
+            "indexes": [
+                0,
+                83
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_84hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_84hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_84hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_84hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 302400,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                90,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_90",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_90",
+            "dType": "float",
+            "indexes": [
+                0,
+                89
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_90hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_90hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_90hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_90hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 324000,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                96,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_96",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_96",
+            "dType": "float",
+            "indexes": [
+                0,
+                95
+            ]
+        }
+    ]
+}

--- a/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_96hr.json
+++ b/data/dspec/ColdStunning/Esperitu-Santo-Bay_Water-Temperature_96hr.json
@@ -1,0 +1,252 @@
+{
+    "dspecVersion": "2.0",
+    "modelName": "Espiritu-Santo-Bay_Water-Temperature_96hr",
+    "modelVersion": "1.0.0",
+    "author": "Ayesha Khan",
+    "modelFileName": "./ColdStunning/Espiritu-Santo-Bay_Water-Temperature_96hr",
+    "timingInfo": {
+        "active": true,
+        "offset": 1500,
+        "interval": 3600
+    },
+    "outputInfo": {
+        "outputMethod": "DefaultOutputHandler",
+        "leadTime": 345600,
+        "series": "pWaterTmp",
+        "location": "EspirituSantoBay",
+        "unit": "celsius"
+    },
+    "dependentSeries": [
+        {
+            "_name": "Water Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Water_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dWaterTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_water-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PL",
+            "location": "PortLavaca",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-Lavaca_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_SD",
+            "location": "Seadrift",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Seadrift_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_PO",
+            "location": "PortOConnor",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Port-OConnor_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Air_Temp_AWR",
+            "location": "AransasWildlifeRefuge",
+            "source": "LIGHTHOUSE",
+            "series": "dAirTmp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                1,
+                -26
+            ],
+            "outKey": "Aransas-Wildlife-Refuge_air-temp_25",
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            }
+        },
+        {
+            "_name": "Predicted Air Temp",
+            "location": "EspirituSantoBay",
+            "source": "NDFD_JSON",
+            "series": "pAirTemp",
+            "unit": "celsius",
+            "interval": 3600,
+            "range": [
+                102,
+                1
+            ],
+            "outKey": "Espiritu-Santo-Bay_predicted_air-temp_102",
+            "stalenessOffset": 45000,
+            "dataIntegrityCall": {
+                "call": "PandasInterpolation",
+                "args": {
+                    "limit": "21600",
+                    "method": "linear",
+                    "limit_area": "inside"
+                }
+            }
+        }
+    ],
+    "postProcessCall": [
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": false,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_air-temp_25",
+                    "Port-OConnor_air-temp_25",
+                    "Seadrift_air-temp_25",
+                    "Port-Lavaca_air-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_air-temp_25"
+            }
+        },
+        {
+            "call": "ComputeMean",
+            "args": {
+                "dropOutlierSeries": true,
+                "thresholdDeviationFromMedian": 3.5,
+                "sentinel_value": 10000,
+                "targetSeries": [
+                    "Aransas-Wildlife-Refuge_water-temp_25",
+                    "Port-OConnor_water-temp_25",
+                    "Seadrift_water-temp_25",
+                    "Port-Lavaca_water-temp_25"
+                ],
+                "outKey": "Espiritu-Santo-Bay_water-temp_25"
+            }
+        }
+    ],
+    "vectorOrder": [
+        {
+            "key": "Espiritu-Santo-Bay_water-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_air-temp_25",
+            "dType": "float",
+            "indexes": [
+                2,
+                26
+            ]
+        },
+        {
+            "key": "Espiritu-Santo-Bay_predicted_air-temp_102",
+            "dType": "float",
+            "indexes": [
+                0,
+                101
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The models have the following requirements:

**Input Series:**
1. Water temperature measurements: 
          * Locations: Port O'Connor, Seadrift, Port Lavaca, and Aransas Wildlife Refuge
          * Interval: every hour = 3600 seconds
          * range = 24 hours. request [1,-26] to maximize chances to get end points (e.,g now and 24 hours)
          * data integrity = replace missing value with sentinel value to pass data validation
2. Air temperature measurements: 
          * Locations: Port O'Connor, Seadrift, Port Lavaca, and Aransas Wildlife Refuge
          * Interval: every hour = 3600 seconds
          * range = 24 hours. request [1,-26] to maximize chances to get end points (e.,g now and 24 hours)
          *  data integrity = replace missing value with sentinel value to pass data validation
3. Air temperature predictions:
         * Location: Espirity Santo Bay
         * Interval: every hour = 3600 seconds
         * Range: up to lead time + 6 hours, e.g., 3 hours lead time = hours 1 to 9, 12 hours lead time = hours 1 to 18
         * Override staleness offset (because it's ndfd) to 45000 seconds (12.5 hours)
         * data integrity:  pandas interpolation 
                         *  maximum gap of 6 hours (21600 seconds), 
                         *  method: linear, inside

**Vector Order Series**
1. air temp measurements for ESB as the mean of the air temp measurements of the 4 TCOON stations, dropping stations that have missing values.
2. water temp measurements for ESB as the mean of the water temp measurements of the 4 TCOON stations , dropping stations that have missing values and stations that have wild outliers where an outlier is anything that is 3.5 deg celcius away from the median.
3. air temp predictions -- no post processing

The proposed DSPEC assumes the following:
1. we will create a data integrity class to replace any value that is missing after ingestion with a sentinel value. This is so that we can pass data validation which occurs before post processing. The post processing call will then decide when to drop stations that do not have enough data by interpreting the the sentinel value as NaN.
2. we will create a post processing class that takes a number of series and computes the mean for each verified time.  The class will decide when a series should not be used to compute the mean.   We can use the same class to compute the mean for the air temp measurements as for the water temp measurements but pass different arguments to it to control the required differences in behavior (see requirements above).