### PR TITLE
1002 create dataintegrity class for esb models

### DIFF
--- a/src/DataClasses.py
+++ b/src/DataClasses.py
@@ -130,6 +130,8 @@ class Series():
         self.description = description
         self.timeDescription = timeDescription
         self.__dataFrame = None
+        self.__sentinelValue = None
+
 
     @property
     def dataFrame(self):
@@ -138,6 +140,15 @@ class Series():
     @dataFrame.setter
     def dataFrame(self, dataFrame: DataFrame) -> None:
         self.__dataFrame = dataFrame
+
+    @property
+    def sentinelValue(self):
+        return self.__sentinelValue
+
+    @sentinelValue.setter
+    def sentinelValue(self, sentinelValue: int) -> None:
+        self.__sentinelValue = sentinelValue
+
 
     def __str__(self) -> str:
         return f'\n[Series] -> description: {self.description}, timeDescription: {self.timeDescription}'

--- a/src/DataIntegrity/DataIntegrityClasses/ReplaceMissingValues.py
+++ b/src/DataIntegrity/DataIntegrityClasses/ReplaceMissingValues.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+# SentinelInsertion.py
+#----------------------------------
+# Created By: Anointiyae Beasley
+# Created Date: 08/10/2026
+# version 1.0
+#----------------------------------
+"""This module uses pandas to insert sentinel values for missing data.
+ """ 
+#----------------------------------
+# 
+#
+#Imports
+import pandas as pd
+from datetime import datetime, timedelta
+
+from DataIntegrity.IDataIntegrity import IDataIntegrity
+from DataClasses import Series
+from utility import log
+
+from exceptions import Semaphore_Data_Exception
+
+
+
+class ReplaceMissingValues(IDataIntegrity):
+    """
+    This class inserts sentinel values for missing data. A sentinel value is a unique value in an algorithm or data structure that acts as a marker or signal for a specific condition, such as the end of a loop, the end of a data sequence, or a missing input.
+
+    args: 
+            sentinel_value - The value to use for missing data.
+            method - The Pandas method to interpolate with.
+
+
+    json_copy:
+    "dataIntegrityCall": {
+        "call": "ReplaceMissingValues",
+        "args": {
+            "sentinel_value":""
+        }
+    }
+    """
+
+    # Find rows that have values that are set to None or NaN
+    # Replace those values with given sentinel value
+
+    def exec(self, inSeries: Series) -> Series: 
+        """This method will insert sentinel values for missing data
+
+    Args:
+        inSeries (Series): The incomplete merged result of the DB and DI queries
+
+    Returns:
+        Series : The Series with new sentinel values added
+    """
+        timeDescription = inSeries.timeDescription
+        seriesDescription = inSeries.description
+        dataIntegrityDescription = seriesDescription.dataIntegrityDescription
+    
+        # If there is only one Input (only one data point) then we do not interpolate
+        if(len(inSeries.dataFrame) <= 1):
+            log(f'''Interpolation error,
+                Reason: Only one Input found in series.
+            ''')
+            return inSeries
+        
+        sentinel_value = dataIntegrityDescription.args.get('sentinel_value', None)
+        if sentinel_value is None or sentinel_value == 0:
+            error_message = f'''Interpolation error,
+                Reason: Sentinel value is either not set in the Data Integrity Description or is invalid.
+                dataIntegrityDescription:
+                {dataIntegrityDescription}
+            '''
+            raise Semaphore_Data_Exception(error_message)
+    
+        input_df = inSeries.dataFrame
+        
+        input_df.set_index('timeVerified', inplace=True)
+        
+        # Add the missing timeVerified datetimes and fill the remaining columns with NaNs/NaTs
+        filled_input_df = self.__fill_in_date_gaps(input_df, timeDescription.fromDateTime, timeDescription.toDateTime, timeDescription.interval)
+        
+        # Rename the index back to 'timeVerified' after filling in date gaps
+        filled_input_df.index = filled_input_df.index.rename('timeVerified')
+
+        # Convert dataValue to numbers; Inserted str "NaN" will be converted to actual NaN values
+        filled_input_df["dataValue"] = pd.to_numeric(
+            filled_input_df["dataValue"],
+            errors="coerce",
+        )
+
+        # Replace NaN with the sentinel value
+        filled_input_df["dataValue"] = (
+            filled_input_df["dataValue"].fillna(sentinel_value)
+        )
+
+        # Convert dataValue back to string
+        filled_input_df['dataValue'] = filled_input_df['dataValue'].astype(str)
+
+        # Reset the index to make timeVerified a normal column again
+        filled_input_df.reset_index(inplace=True)
+
+        # Convert timeGenerated to object from datetime64[ns] such that it can be converted to None
+        filled_input_df['timeGenerated'] = filled_input_df['timeGenerated'].astype('object')
+
+        # Set NaT timeGenerated to None
+        filled_input_df.loc[filled_input_df['timeGenerated'].isnull(), 'timeGenerated'] = None
+    
+        outSeries = Series(seriesDescription, timeDescription)
+        outSeries.dataFrame = filled_input_df
+        outSeries.sentinelValue = sentinel_value
+
+        return outSeries
+             
+    def __fill_in_date_gaps(self, df : pd.DataFrame , start_date : datetime , end_date : datetime , interval : timedelta ) -> pd.DataFrame:
+        """Fills in missing date gaps with NaNs based on given interval. The DataFrame index must be of type datetime
+
+            Args:
+                df [DataFrame]: pandas DataFrame
+
+                start_date (datetime): Date to start at
+
+                end_date (datetime): Date to end at
+
+                interval (timedelta): The time step separating the data points in order
+
+            Returns:
+                [DataFrame]: pandas DataFrame containing desired data
+            """
+
+        all_dates = pd.date_range(start=start_date, end=end_date, freq=interval)
+
+        all_dates_df = pd.DataFrame(index=all_dates)
+
+        merged_df = pd.merge(all_dates_df, df, left_index=True, right_index=True, how='left')
+
+        return merged_df

--- a/src/DataIntegrity/DataIntegrityClasses/ReplaceMissingValues.py
+++ b/src/DataIntegrity/DataIntegrityClasses/ReplaceMissingValues.py
@@ -58,14 +58,14 @@ class ReplaceMissingValues(IDataIntegrity):
     
         # If there is only one Input (only one data point) then we do not interpolate
         if(len(inSeries.dataFrame) <= 1):
-            log(f'''Interpolation error,
+            log(f'''ReplaceMissingValues error,
                 Reason: Only one Input found in series.
             ''')
             return inSeries
         
         sentinel_value = dataIntegrityDescription.args.get('sentinel_value', None)
         if sentinel_value is None or sentinel_value == 0:
-            error_message = f'''Interpolation error,
+            error_message = f'''ReplaceMissingValues error,
                 Reason: Sentinel value is either not set in the Data Integrity Description or is invalid.
                 dataIntegrityDescription:
                 {dataIntegrityDescription}

--- a/src/tests/UnitTests/test_ReplaceMissingValues.py
+++ b/src/tests/UnitTests/test_ReplaceMissingValues.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#test_ReplaceMissingValues.py
+#-------------------------------
+# Created By: Anointiyae Beasley  
+# Created Date: 08/11/2026
+#----------------------------------
+"""This file tests the ReplaceMissingValues method and the other methods within it
+
+run: docker exec semaphore-core python3 -m pytest src/tests/UnitTests/test_ReplaceMissingValues.py
+ """ 
+#----------------------------------
+# 
+#Imports
+import sys
+sys.path.append('/app/src')
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from src.DataClasses import get_input_dataFrame, Series, SeriesDescription, TimeDescription, DataIntegrityDescription
+from src.DataIntegrity.IDataIntegrity import data_integrity_factory
+from pandas import DataFrame
+from src.exceptions import Semaphore_Data_Exception
+
+#Test that the ReplaceMissingValues class correctly replaces missing values with the sentinel value provided in the DataIntegrityDescription. 
+#The test will check that the length of the output series is as expected and that there are no NaN or invalid values in the output series.
+dependent_series = {
+            "_name": "Wind Direction",
+            "location": "packChan",
+            "source": "NOAATANDC",
+            "series": "dWnDir",
+            "unit": "degrees",
+            "interval": 3600,
+            "range": [0, 11],
+            "datum": None,
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": 10000
+                }
+            },
+            "outKey": "WindDir_01",
+            "verificationOverride": None
+        }
+
+testTimeDescription = TimeDescription(datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=10, tzinfo=timezone.utc),  timedelta(seconds = 3600))
+
+
+original_df = get_input_dataFrame()
+original_df.loc[0] = ['0.6', 'test', datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+original_df.loc[1] = ['0.66', 'test', datetime(2024, 1, 1, hour=1, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+original_df.loc[2] = ['0.69', 'test', datetime(2024, 1, 1, hour=2, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+original_df.loc[3] = ['0.72', 'test', datetime(2024, 1, 1, hour=6, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+original_df.loc[4] = ['0.76', 'test', datetime(2024, 1, 1, hour=7, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+
+
+expected_df = get_input_dataFrame()
+expected_df.loc[0] = ['0.6', 'test', datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[1] = ['0.66', 'test', datetime(2024, 1, 1, hour=1, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[2] = ['0.69', 'test', datetime(2024, 1, 1, hour=2, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[3] = ['10000.0', 'test', datetime(2024, 1, 1, hour=3, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[4] = ['10000.0', 'test', datetime(2024, 1, 1, hour=4, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[5] = ['10000.0', 'test', datetime(2024, 1, 1, hour=5, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[6] = ['0.72', 'test', datetime(2024, 1, 1, hour=6, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[7] = ['0.76', 'test', datetime(2024, 1, 1, hour=7, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[8] = ['10000.0', 'test', datetime(2024, 1, 1, hour=8, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[9] = ['10000.0', 'test', datetime(2024, 1, 1, hour=9, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_df.loc[10] = ['10000.0', 'test', datetime(2024, 1, 1, hour=10, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+
+@pytest.mark.parametrize("dependent_series, timeDescription, inputs, expected_df", [
+    (dependent_series, testTimeDescription, original_df, expected_df), # One value missing, expects len of 7, no NaNs
+])
+def test_replace_missing_values(dependent_series: list, timeDescription: TimeDescription, inputs: DataFrame, expected_df: DataFrame):
+    seriesDescription = SeriesDescription(
+        dependent_series["source"],
+        dependent_series["series"],
+        dependent_series["location"],
+        dataIntegrityDescription= DataIntegrityDescription(
+            dependent_series["dataIntegrityCall"]['call'],
+            dependent_series["dataIntegrityCall"]['args']
+        )
+    )
+    
+    inSeries = Series(description = seriesDescription, timeDescription = timeDescription)
+
+    inSeries.dataFrame = inputs.copy(deep=True)
+
+
+    #Call the ReplaceMissingValues class and execute the exec method
+    data_integrity_class = data_integrity_factory(seriesDescription.dataIntegrityDescription.call)
+    outSeries = data_integrity_class.exec(inSeries)
+    print(f'inSeries.dataFrame: {inSeries.dataFrame}')
+    print(f'outSeries.dataFrame: {outSeries.dataFrame}')
+
+    actual_length_of_data = len(outSeries.dataFrame)
+    print(f'actual_length_of_data: {actual_length_of_data}')
+
+    print(f'outSeries.dataFrame dataValue List: {outSeries.dataFrame["dataValue"].values.tolist()}')
+    print(f'expected_df dataValue List: {expected_df["dataValue"].values.tolist()}')
+
+    assert actual_length_of_data == 11
+    assert outSeries.dataFrame['dataValue'].values.tolist() == expected_df['dataValue'].values.tolist()

--- a/src/tests/UnitTests/test_ReplaceMissingValues.py
+++ b/src/tests/UnitTests/test_ReplaceMissingValues.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta, timezone
 from src.DataClasses import get_input_dataFrame, Series, SeriesDescription, TimeDescription, DataIntegrityDescription
 from src.DataIntegrity.IDataIntegrity import data_integrity_factory
 from pandas import DataFrame
-from src.exceptions import Semaphore_Data_Exception
 
 #Test that the ReplaceMissingValues class correctly replaces missing values with the sentinel value provided in the DataIntegrityDescription. 
 #The test will check that the length of the output series is as expected and that there are no NaN or invalid values in the output series.
@@ -37,6 +36,25 @@ dependent_series = {
                 "call": "ReplaceMissingValues",
                 "args": {
                     "sentinel_value": 10000
+                }
+            },
+            "outKey": "WindDir_01",
+            "verificationOverride": None
+        }
+
+dependent_series_string= {
+            "_name": "Wind Direction",
+            "location": "packChan",
+            "source": "NOAATANDC",
+            "series": "dWnDir",
+            "unit": "degrees",
+            "interval": 3600,
+            "range": [0, 11],
+            "datum": None,
+            "dataIntegrityCall": {
+                "call": "ReplaceMissingValues",
+                "args": {
+                    "sentinel_value": "missing"
                 }
             },
             "outKey": "WindDir_01",
@@ -67,8 +85,22 @@ expected_df.loc[8] = ['10000.0', 'test', datetime(2024, 1, 1, hour=8, tzinfo=tim
 expected_df.loc[9] = ['10000.0', 'test', datetime(2024, 1, 1, hour=9, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
 expected_df.loc[10] = ['10000.0', 'test', datetime(2024, 1, 1, hour=10, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
 
+expected_string_df = get_input_dataFrame()
+expected_string_df.loc[0] = ['0.6', 'test', datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[1] = ['0.66', 'test', datetime(2024, 1, 1, hour=1, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[2] = ['0.69', 'test', datetime(2024, 1, 1, hour=2, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[3] = ['missing', 'test', datetime(2024, 1, 1, hour=3, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[4] = ['missing', 'test', datetime(2024, 1, 1, hour=4, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[5] = ['missing', 'test', datetime(2024, 1, 1, hour=5, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[6] = ['0.72', 'test', datetime(2024, 1, 1, hour=6, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[7] = ['0.76', 'test', datetime(2024, 1, 1, hour=7, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[8] = ['missing', 'test', datetime(2024, 1, 1, hour=8, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[9] = ['missing', 'test', datetime(2024, 1, 1, hour=9, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+expected_string_df.loc[10] = ['missing', 'test', datetime(2024, 1, 1, hour=10, tzinfo=timezone.utc), datetime(2024, 1, 1, hour=0, tzinfo=timezone.utc), None, None]
+
 @pytest.mark.parametrize("dependent_series, timeDescription, inputs, expected_df", [
     (dependent_series, testTimeDescription, original_df, expected_df), # One value missing, expects len of 7, no NaNs
+    (dependent_series_string, testTimeDescription, original_df, expected_string_df), # String value, expects len of 7, no NaNs
 ])
 def test_replace_missing_values(dependent_series: list, timeDescription: TimeDescription, inputs: DataFrame, expected_df: DataFrame):
     seriesDescription = SeriesDescription(
@@ -88,11 +120,16 @@ def test_replace_missing_values(dependent_series: list, timeDescription: TimeDes
 
     #Call the ReplaceMissingValues class and execute the exec method
     data_integrity_class = data_integrity_factory(seriesDescription.dataIntegrityDescription.call)
+
+
     outSeries = data_integrity_class.exec(inSeries)
+
+
+    actual_length_of_data = len(outSeries.dataFrame)
+
     print(f'inSeries.dataFrame: {inSeries.dataFrame}')
     print(f'outSeries.dataFrame: {outSeries.dataFrame}')
 
-    actual_length_of_data = len(outSeries.dataFrame)
     print(f'actual_length_of_data: {actual_length_of_data}')
 
     print(f'outSeries.dataFrame dataValue List: {outSeries.dataFrame["dataValue"].values.tolist()}')


### PR DESCRIPTION
# Context

---

<img width="864" height="482" alt="image" src="https://github.com/user-attachments/assets/2115646c-7fd0-4bdd-9ee8-007829ce33cf" />


The four station input series pass through data validation before post-processing. If missing values remain at validation time, the model fails before it can calculate a mean, median, or perform other post-processing.

The agreed approach is therefore:

1. Replace missing station observations with sentinel values before validation.
2. Allow the series to pass validation.
3. Handle those sentinel values during post-processing.

Sentinels represent missing data and must not be included in statistical calculations.

# How to test
- docker compose up -d --build
- docker exec semaphore-core python -m pytest -s  src/tests/UnitTests/test_ReplaceMissingValues.py